### PR TITLE
Update Mesos scheduler to make leaseOfferExpiration and declinedOfferRefuse duration configurable

### DIFF
--- a/docs/_includes/generated/mesos_configuration.html
+++ b/docs/_includes/generated/mesos_configuration.html
@@ -38,6 +38,11 @@
             <td>Enables SSL for the Flink artifact server. Note that security.ssl.enabled also needs to be set to true encryption to enable encryption.</td>
         </tr>
         <tr>
+            <td><h5>mesos.resourcemanager.declined-offer-refuse-duration</h5></td>
+            <td style="word-wrap: break-word;">5000</td>
+            <td>Amount of time to ask the Mesos master to not resend a declined resource offer again. This ensures a declined resource offer isn't resent immediately after being declined</td>
+        </tr>
+        <tr>
             <td><h5>mesos.resourcemanager.framework.name</h5></td>
             <td style="word-wrap: break-word;">"Flink"</td>
             <td>Mesos framework name</td>
@@ -63,9 +68,24 @@
             <td>Mesos framework user</td>
         </tr>
         <tr>
+            <td><h5>mesos.resourcemanager.max-offers-expire</h5></td>
+            <td style="word-wrap: break-word;">4</td>
+            <td>If reject-all-expired=false, this option specifies the max number of unused expired Mesos offers that are rejected at a time.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.reject-all-expired</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Option to reject all expired unused Mesos offers. If false, the number expired are specified by max-offers-expire.</td>
+        </tr>
+        <tr>
             <td><h5>mesos.resourcemanager.tasks.port-assignments</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Comma-separated list of configuration keys which represent a configurable port. All port keys will dynamically get a port assigned through Mesos.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.unusedoffer-expiration</h5></td>
+            <td style="word-wrap: break-word;">12000</td>
+            <td>Amount of time to wait for unused expired offers before declining them. This ensures your scheduler will not hoard unuseful offers.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/mesos_configuration.html
+++ b/docs/_includes/generated/mesos_configuration.html
@@ -84,7 +84,7 @@
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.unusedoffer-expiration</h5></td>
-            <td style="word-wrap: break-word;">12000</td>
+            <td style="word-wrap: break-word;">120000</td>
             <td>Amount of time to wait for unused expired offers before declining them. This ensures your scheduler will not hoard unuseful offers.</td>
         </tr>
     </tbody>

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
@@ -144,4 +144,54 @@ public class MesosOptions {
 				"All port keys will dynamically get a port assigned through Mesos.")
 			.build());
 
+	/**
+	 * Config parameter to reject all expired unused Mesos offers.
+	 */
+	public static final ConfigOption<Boolean> REJECT_ALL_EXPIRED_OFFERS =
+		key("mesos.resourcemanager.reject-all-expired")
+			.defaultValue(false)
+			.withDescription(
+				Description.builder()
+					.text("Option to reject all expired unused Mesos offers. If false, " +
+						"the number expired are specified by max-offers-expire.")
+					.build());
+
+	/**
+	 * Config parameter to specify the maximum number of unused expired Mesos offers to reject.
+	 */
+	public static final ConfigOption<Integer> MAX_OFFERS_TO_EXPIRE =
+		key("mesos.resourcemanager.max-offers-expire")
+			.defaultValue(4)
+			.withDescription(
+				Description.builder()
+					.text("If reject-all-expired=false, this option specifies the max number " +
+						"of unused expired Mesos offers that are rejected at a time.")
+					.build());
+
+	/**
+	 * Config parameter to configure the amount of time to wait for unused expired Mesos
+	 * offers before they are declined.
+	 */
+	public static final ConfigOption<Long> UNUSED_OFFER_EXPIRATION =
+		key("mesos.resourcemanager.unusedoffer-expiration")
+			.defaultValue(12000L)
+			.withDescription(
+				Description.builder()
+					.text("Amount of time to wait for unused expired offers before declining them. " +
+						"This ensures your scheduler will not hoard unuseful offers.")
+					.build());
+
+	/**
+	 * Config parameter to configure the amount of time refuse a particular offer for.
+	 * This ensures the same resource offer isn't resent immediately after declining.
+	 */
+	public static final ConfigOption<Long> DECLINED_OFFER_REFUSE_DURATION =
+		key("mesos.resourcemanager.declined-offer-refuse-duration")
+			.defaultValue(5000L)
+			.withDescription(
+				Description.builder()
+					.text("Amount of time to ask the Mesos master to not resend a " +
+						"declined resource offer again. This ensures a declined resource offer " +
+						"isn't resent immediately after being declined")
+					.build());
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
@@ -174,7 +174,7 @@ public class MesosOptions {
 	 */
 	public static final ConfigOption<Long> UNUSED_OFFER_EXPIRATION =
 		key("mesos.resourcemanager.unusedoffer-expiration")
-			.defaultValue(12000L)
+			.defaultValue(120000L)
 			.withDescription(
 				Description.builder()
 					.text("Amount of time to wait for unused expired offers before declining them. " +

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManager.java
@@ -724,8 +724,20 @@ public class MesosFlinkResourceManager extends FlinkResourceManager<RegisteredMe
 			}
 
 			@Override
+			public TaskSchedulerBuilder withMaxOffersToReject(int maxOffersToReject) {
+				builder.withMaxOffersToReject(maxOffersToReject);
+				return this;
+			}
+
+			@Override
 			public TaskSchedulerBuilder withRejectAllExpiredOffers() {
 				builder.withRejectAllExpiredOffers();
+				return this;
+			}
+
+			@Override
+			public TaskSchedulerBuilder withLeaseOfferExpirySecs(long leaseOfferExpirySecs) {
+				builder.withLeaseOfferExpirySecs(leaseOfferExpirySecs);
 				return this;
 			}
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -776,8 +776,20 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			}
 
 			@Override
+			public TaskSchedulerBuilder withMaxOffersToReject(int maxOffersToReject) {
+				builder.withMaxOffersToReject(maxOffersToReject);
+				return this;
+			}
+
+			@Override
 			public TaskSchedulerBuilder withRejectAllExpiredOffers() {
 				builder.withRejectAllExpiredOffers();
+				return this;
+			}
+
+			@Override
+			public TaskSchedulerBuilder withLeaseOfferExpirySecs(long leaseOfferExpirySecs) {
+				builder.withLeaseOfferExpirySecs(leaseOfferExpirySecs);
 				return this;
 			}
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/scheduler/TaskSchedulerBuilder.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/scheduler/TaskSchedulerBuilder.java
@@ -35,9 +35,20 @@ public interface TaskSchedulerBuilder {
 	TaskSchedulerBuilder withLeaseRejectAction(Action1<VirtualMachineLease> action);
 
 	/**
+	 * Configure the maximun number of expired unused offers to reject (if
+	 * rejectAllExpiredOffers isn't set).
+	 */
+	TaskSchedulerBuilder withMaxOffersToReject(int maxOffersToReject);
+
+	/**
 	 * Set up TaskScheduler to reject all offers on expiry.
 	 */
 	TaskSchedulerBuilder withRejectAllExpiredOffers();
+
+	/**
+	 * Specify the expiration time for unused resource offers.
+	 */
+	TaskSchedulerBuilder withLeaseOfferExpirySecs(long leaseOfferExpirySecs);
 
 	/**
 	 * Build a Fenzo task scheduler.

--- a/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/LaunchCoordinator.scala
+++ b/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/LaunchCoordinator.scala
@@ -19,22 +19,24 @@
 package org.apache.flink.mesos.scheduler
 
 import java.util.Collections
+import java.util.concurrent.TimeUnit
 
 import akka.actor.{Actor, ActorRef, FSM, Props}
 import com.netflix.fenzo._
 import com.netflix.fenzo.functions.Action1
 import grizzled.slf4j.Logger
-import org.apache.flink.api.java.tuple.{Tuple2=>FlinkTuple2}
+import org.apache.flink.api.java.tuple.{Tuple2 => FlinkTuple2}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.mesos.Utils
 import org.apache.flink.mesos.scheduler.LaunchCoordinator._
 import org.apache.flink.mesos.scheduler.messages._
 import org.apache.flink.mesos.util.MesosResourceAllocation
-import org.apache.mesos.{SchedulerDriver, Protos}
+import org.apache.mesos.{Protos, SchedulerDriver}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{Map => MutableMap}
 import scala.concurrent.duration._
+import org.apache.flink.mesos.configuration.MesosOptions._
 
 /**
   * The launch coordinator handles offer processing, including
@@ -54,6 +56,18 @@ class LaunchCoordinator(
 
   val LOG = Logger(getClass)
 
+  val declineOfferFilters: Protos.Filters =
+    Protos.Filters.newBuilder()
+      .setRefuseSeconds(
+        Duration(config.getLong(DECLINED_OFFER_REFUSE_DURATION), TimeUnit.MILLISECONDS).toSeconds)
+      .build()
+
+  val unusedOfferExpirationDuration: Long =
+    Duration(config.getLong(UNUSED_OFFER_EXPIRATION), TimeUnit.MILLISECONDS).toSeconds
+
+  val rejectAllExpiredOffers: Boolean = config.getBoolean(REJECT_ALL_EXPIRED_OFFERS)
+  val maxOffersToExpire: Int = config.getInteger(MAX_OFFERS_TO_EXPIRE)
+
   /**
     * The task placement optimizer.
     *
@@ -62,19 +76,25 @@ class LaunchCoordinator(
     *  - existing task placement (for fitness calculation involving task colocation)
     */
   private[mesos] val optimizer: TaskScheduler = {
-    optimizerBuilder
-      .withLeaseRejectAction(new Action1[VirtualMachineLease]() {
-        def call(lease: VirtualMachineLease) {
-          LOG.info(s"Declined offer ${lease.getId} from ${lease.hostname()} "
-            + s"of memory ${lease.memoryMB()} MB, ${lease.cpuCores()} cpus, "
-            + s"${lease.getScalarValue("gpus")} gpus, "
-            + s"of disk: ${lease.diskMB()} MB, network: ${lease.networkMbps()} Mbps")
-          schedulerDriver.declineOffer(lease.getOffer.getId)
+    val builder =
+      optimizerBuilder
+        .withLeaseRejectAction(new Action1[VirtualMachineLease]() {
+          def call(lease: VirtualMachineLease) {
+            LOG.info(s"Declined offer ${lease.getId} from ${lease.hostname()} "
+              + s"of memory ${lease.memoryMB()} MB, ${lease.cpuCores()} cpus, "
+              + s"${lease.getScalarValue("gpus")} gpus, "
+              + s"of disk: ${lease.diskMB()} MB, network: ${lease.networkMbps()} Mbps "
+              + s"for the next ${declineOfferFilters.getRefuseSeconds} seconds")
+            schedulerDriver.declineOffer(lease.getOffer.getId, declineOfferFilters)
         }
       })
-      // avoid situations where we have lots of expired offers and we only expire a few at a time
-      .withRejectAllExpiredOffers()
-      .build
+      .withLeaseOfferExpirySecs(unusedOfferExpirationDuration)
+
+      if (rejectAllExpiredOffers) {
+        builder.withRejectAllExpiredOffers().build
+      } else {
+        builder.withMaxOffersToReject(maxOffersToExpire).build
+      }
   }
 
   override def postStop(): Unit = {
@@ -114,7 +134,9 @@ class LaunchCoordinator(
     case Event(offers: ResourceOffers, data: GatherData) =>
       // decline any offers that come in
       schedulerDriver.suppressOffers()
-      for(offer <- offers.offers().asScala) { schedulerDriver.declineOffer(offer.getId) }
+      for(offer <- offers.offers().asScala) {
+        schedulerDriver.declineOffer(offer.getId, declineOfferFilters)
+      }
       stay()
 
     case Event(msg: Launch, data: GatherData) =>

--- a/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
+++ b/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.mesos.scheduler
 
+import java.util.concurrent.TimeUnit
 import java.util.{Collections, UUID}
 import java.util.concurrent.atomic.AtomicReference
 
@@ -26,27 +27,29 @@ import akka.testkit._
 import com.netflix.fenzo.TaskRequest.{AssignedResources, NamedResourceSetRequest}
 import com.netflix.fenzo._
 import com.netflix.fenzo.functions.{Action1, Action2}
-import org.apache.flink.api.java.tuple.{Tuple2=>FlinkTuple2}
+import org.apache.flink.api.java.tuple.{Tuple2 => FlinkTuple2}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.mesos.scheduler.LaunchCoordinator._
 import org.apache.flink.mesos.scheduler.messages._
 import org.apache.flink.runtime.akka.AkkaUtils
 import org.apache.mesos.Protos.{SlaveID, TaskInfo}
-import org.apache.mesos.{SchedulerDriver, Protos}
+import org.apache.mesos.{Protos, SchedulerDriver}
 import org.junit.runner.RunWith
 import org.mockito.Mockito.{verify, _}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.mockito.{Matchers => MM, Mockito}
+import org.mockito.{Mockito, Matchers => MM}
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 import scala.collection.JavaConverters._
-
 import org.apache.flink.mesos.Utils.range
 import org.apache.flink.mesos.Utils.ranges
 import org.apache.flink.mesos.Utils.scalar
+import org.apache.flink.mesos.configuration.MesosOptions.DECLINED_OFFER_REFUSE_DURATION
 import org.apache.flink.mesos.util.MesosResourceAllocation
+
+import scala.concurrent.duration.Duration
 
 @RunWith(classOf[JUnitRunner])
 class LaunchCoordinatorTest
@@ -201,6 +204,9 @@ class LaunchCoordinatorTest
   def taskSchedulerBuilder(optimizer: TaskScheduler) = new TaskSchedulerBuilder {
     var leaseRejectAction: Action1[VirtualMachineLease] = null
     var rejectAllExpiredOffers: Boolean = false
+    var leaseOfferExpiry: Long = 0L
+    var offersToReject: Int = 0
+
     override def withLeaseRejectAction(
         action: Action1[VirtualMachineLease]): TaskSchedulerBuilder = {
       leaseRejectAction = action
@@ -211,7 +217,18 @@ class LaunchCoordinatorTest
       this
     }
 
+    override def withLeaseOfferExpirySecs(leaseOfferExpirySecs: Long): TaskSchedulerBuilder = {
+      leaseOfferExpiry = leaseOfferExpirySecs
+      this
+    }
+
+    override def withMaxOffersToReject(maxOffersToReject: Int): TaskSchedulerBuilder = {
+      offersToReject = maxOffersToReject
+      this
+    }
+
     override def build(): TaskScheduler = optimizer
+
   }
 
   /**
@@ -238,6 +255,11 @@ class LaunchCoordinatorTest
     val trace = Mockito.inOrder(schedulerDriver)
     val fsm =
       TestFSMRef(new LaunchCoordinator(testActor, config, schedulerDriver, optimizerBuilder))
+    val refuseFilter =
+      Protos.Filters.newBuilder()
+        .setRefuseSeconds(
+          Duration(config.getLong(DECLINED_OFFER_REFUSE_DURATION), TimeUnit.MILLISECONDS).toSeconds)
+        .build()
 
     val framework = randomFramework
     val task1 = randomTask
@@ -320,8 +342,8 @@ class LaunchCoordinatorTest
         "stays in Idle with offers declined" in new Context {
           fsm.setState(Idle)
           fsm ! new ResourceOffers(Seq(slave1._3, slave1._4).asJava)
-          verify(schedulerDriver).declineOffer(slave1._3.getId)
-          verify(schedulerDriver).declineOffer(slave1._4.getId)
+          verify(schedulerDriver).declineOffer(slave1._3.getId, refuseFilter)
+          verify(schedulerDriver).declineOffer(slave1._4.getId, refuseFilter)
           fsm.stateName should be (Idle)
         }
       }
@@ -461,7 +483,7 @@ class LaunchCoordinatorTest
           fsm.setState(GatheringOffers,
             GatherData(tasks = Seq(task1._2), newLeases = Seq(lease(slave1._3))))
           fsm ! StateTimeout
-          verify(schedulerDriver).declineOffer(slave1._3.getId)
+          verify(schedulerDriver).declineOffer(slave1._3.getId, refuseFilter)
         }
       }
 


### PR DESCRIPTION
Follow up to the review (https://github.com/criteo-forks/flink/pull/10) as we're still seeing super skewed resource offers from Mesos causing our jobs to take very long to schedule with the quotas we have in place. 
This review adds configuration knobs for the following Mesos / Fenzo scheduling options and pipes them down:
- Reject all expired offers - If true when we hit our expiry timeout we reject all the unused expired offers. 
- Max offers to expire - If the rejectAll = false, this option specifies exactly how many unused expired offers we want to reject. 
- Unused offer expiration time - How much time we want to wait before rejecting unused expired offers. 
- Declined Offer Refuse duration - Option to send to the Mesos master that indicates that a rejected resource offer should not be sent back for a certain duration. 

In the previous review we tried out the option of rejecting all expired unused offers. With this one, we can also tune to lower the unused offer expiration time (from 120s -> 1s so we get new hopefully less skewed offers from Mesos sooner) as well as increasing how long Mesos should wait before sending us a declined offer again (5s -> 1min). 

Upstream review: https://github.com/apache/flink/pull/9737