### PR TITLE
Criteo 1.9 historyserverfix

### DIFF
--- a/docs/_includes/generated/history_server_configuration.html
+++ b/docs/_includes/generated/history_server_configuration.html
@@ -8,6 +8,11 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>historyserver.archive.clean-expired-jobs</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Whether HistoryServer should cleanup jobs that are no longer present `historyserver.archive.fs.dir`.</td>
+        </tr>
+        <tr>
             <td><h5>historyserver.archive.fs.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Comma separated list of directories to fetch archived jobs from. The history server will monitor these directories for archived jobs. You can configure the JobManager to archive jobs to a directory via `jobmanager.archive.fs.dir`.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -47,6 +47,16 @@ public class HistoryServerOptions {
 				" directory via `jobmanager.archive.fs.dir`.");
 
 	/**
+	 * If this option is enabled then deleted job archives are also deleted from HistoryServer.
+	 */
+	public static final ConfigOption<Boolean> HISTORY_SERVER_CLEANUP_EXPIRED_JOBS =
+		key("historyserver.archive.clean-expired-jobs")
+			.defaultValue(false)
+			.withDescription(
+				String.format("Whether HistoryServer should cleanup jobs" +
+					" that are no longer present `%s`.", HISTORY_SERVER_ARCHIVE_DIRS.key()));
+
+	/**
 	 * The local directory used by the HistoryServer web-frontend.
 	 */
 	public static final ConfigOption<String> HISTORY_SERVER_WEB_DIR =

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -29,7 +29,6 @@ import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.history.FsJobArchivist;
 import org.apache.flink.runtime.io.network.netty.SSLHandlerFactory;
 import org.apache.flink.runtime.net.SSLUtils;
-import org.apache.flink.runtime.rest.handler.legacy.JsonFactory;
 import org.apache.flink.runtime.rest.handler.router.Router;
 import org.apache.flink.runtime.rest.messages.DashboardConfiguration;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -42,7 +41,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.ShutdownHookUtil;
 
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +51,6 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.file.Files;
 import java.time.ZonedDateTime;
@@ -86,6 +84,7 @@ import java.util.function.Consumer;
 public class HistoryServer {
 
 	private static final Logger LOG = LoggerFactory.getLogger(HistoryServer.class);
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	private final Configuration config;
 
@@ -300,21 +299,7 @@ public class HistoryServer {
 	}
 
 	private static String createConfigJson(DashboardConfiguration dashboardConfiguration) throws IOException {
-		StringWriter writer = new StringWriter();
-		JsonGenerator gen = JsonFactory.JACKSON_FACTORY.createGenerator(writer);
-
-		gen.writeStartObject();
-		gen.writeNumberField(DashboardConfiguration.FIELD_NAME_REFRESH_INTERVAL, dashboardConfiguration.getRefreshInterval());
-		gen.writeNumberField(DashboardConfiguration.FIELD_NAME_TIMEZONE_OFFSET, dashboardConfiguration.getTimeZoneOffset());
-		gen.writeStringField(DashboardConfiguration.FIELD_NAME_TIMEZONE_NAME, dashboardConfiguration.getTimeZoneName());
-		gen.writeStringField(DashboardConfiguration.FIELD_NAME_FLINK_VERSION, dashboardConfiguration.getFlinkVersion());
-		gen.writeStringField(DashboardConfiguration.FIELD_NAME_FLINK_REVISION, dashboardConfiguration.getFlinkRevision());
-
-		gen.writeEndObject();
-
-		gen.close();
-
-		return writer.toString();
+		return OBJECT_MAPPER.writeValueAsString(dashboardConfiguration);
 	}
 
 	/**

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -40,7 +40,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -65,12 +65,13 @@ import java.util.concurrent.TimeUnit;
 @RunWith(Parameterized.class)
 public class HistoryServerTest extends TestLogger {
 
-	@ClassRule
-	public static final TemporaryFolder TMP = new TemporaryFolder();
-
 	private static final JsonFactory JACKSON_FACTORY = new JsonFactory()
 		.enable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
 		.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	@Rule
+	public final TemporaryFolder tmpFolder = new TemporaryFolder();
 
 	private MiniClusterWithClientResource cluster;
 	private File jmDirectory;
@@ -86,8 +87,8 @@ public class HistoryServerTest extends TestLogger {
 
 	@Before
 	public void setUp() throws Exception {
-		jmDirectory = TMP.newFolder("jm_" + versionLessThan14);
-		hsDirectory = TMP.newFolder("hs_" + versionLessThan14);
+		jmDirectory = tmpFolder.newFolder("jm_" + versionLessThan14);
+		hsDirectory = tmpFolder.newFolder("hs_" + versionLessThan14);
 
 		Configuration clusterConfig = new Configuration();
 		clusterConfig.setString(JobManagerOptions.ARCHIVE_DIR, jmDirectory.toURI().toString());
@@ -114,38 +115,51 @@ public class HistoryServerTest extends TestLogger {
 		for (int x = 0; x < numJobs; x++) {
 			runJob();
 		}
+		final int numLegacyJobs = 1;
 		createLegacyArchive(jmDirectory.toPath());
 
-		CountDownLatch numExpectedArchivedJobs = new CountDownLatch(numJobs + 1);
+		waitForArchivesCreation(numJobs + numLegacyJobs);
 
+		CountDownLatch numExpectedArchivedJobs = new CountDownLatch(numJobs + numLegacyJobs);
+
+		Configuration historyServerConfig = createTestConfiguration();
+
+		HistoryServer hs = new HistoryServer(historyServerConfig, numExpectedArchivedJobs);
+
+		try {
+			hs.start();
+			String baseUrl = "http://localhost:" + hs.getWebPort();
+			numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS);
+
+			Assert.assertEquals(numJobs + numLegacyJobs, getJobsOverview(baseUrl).getJobs().size());
+
+		} finally {
+			hs.stop();
+		}
+	}
+
+	private void waitForArchivesCreation(int numJobs) throws InterruptedException {
+		// the job is archived asynchronously after env.execute() returns
+		File[] archives = jmDirectory.listFiles();
+		while (archives == null || archives.length != numJobs) {
+			Thread.sleep(50);
+			archives = jmDirectory.listFiles();
+		}
+	}
+
+	private Configuration createTestConfiguration() {
 		Configuration historyServerConfig = new Configuration();
 		historyServerConfig.setString(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_DIRS, jmDirectory.toURI().toString());
 		historyServerConfig.setString(HistoryServerOptions.HISTORY_SERVER_WEB_DIR, hsDirectory.getAbsolutePath());
 		historyServerConfig.setLong(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL, 100L);
 
 		historyServerConfig.setInteger(HistoryServerOptions.HISTORY_SERVER_WEB_PORT, 0);
+		return historyServerConfig;
+	}
 
-		// the job is archived asynchronously after env.execute() returns
-		File[] archives = jmDirectory.listFiles();
-		while (archives == null || archives.length != numJobs + 1) {
-			Thread.sleep(50);
-			archives = jmDirectory.listFiles();
-		}
-
-		HistoryServer hs = new HistoryServer(historyServerConfig, numExpectedArchivedJobs);
-		try {
-			hs.start();
-			String baseUrl = "http://localhost:" + hs.getWebPort();
-			numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS);
-
-			ObjectMapper mapper = new ObjectMapper();
-			String response = getFromHTTP(baseUrl + JobsOverviewHeaders.URL);
-			MultipleJobsDetails overview = mapper.readValue(response, MultipleJobsDetails.class);
-
-			Assert.assertEquals(numJobs + 1, overview.getJobs().size());
-		} finally {
-			hs.stop();
-		}
+	private MultipleJobsDetails getJobsOverview(String baseUrl) throws Exception {
+		String response = getFromHTTP(baseUrl + JobsOverviewHeaders.URL);
+		return OBJECT_MAPPER.readValue(response, MultipleJobsDetails.class);
 	}
 
 	private static void runJob() throws Exception {
@@ -171,15 +185,15 @@ public class HistoryServerTest extends TestLogger {
 		return IOUtils.toString(is, connection.getContentEncoding() != null ? connection.getContentEncoding() : "UTF-8");
 	}
 
-	private static void createLegacyArchive(Path directory) throws IOException {
-		JobID jobID = JobID.generate();
+	private static String createLegacyArchive(Path directory) throws IOException {
+		JobID jobId = JobID.generate();
 
 		StringWriter sw = new StringWriter();
 		try (JsonGenerator gen = JACKSON_FACTORY.createGenerator(sw)) {
 			try (JsonObject root = new JsonObject(gen)) {
 				try (JsonArray finished = new JsonArray(gen, "finished")) {
 					try (JsonObject job = new JsonObject(gen)) {
-						gen.writeStringField("jid", jobID.toString());
+						gen.writeStringField("jid", jobId.toString());
 						gen.writeStringField("name", "testjob");
 						gen.writeStringField("state", JobStatus.FINISHED.name());
 
@@ -212,7 +226,9 @@ public class HistoryServerTest extends TestLogger {
 
 		ArchivedJson archivedJson = new ArchivedJson("/joboverview", json);
 
-		FsJobArchivist.archiveJob(new org.apache.flink.core.fs.Path(directory.toUri()), jobID, Collections.singleton(archivedJson));
+		FsJobArchivist.archiveJob(new org.apache.flink.core.fs.Path(directory.toUri()), jobId, Collections.singleton(archivedJson));
+
+		return jobId.toString();
 	}
 
 	private static final class JsonObject implements AutoCloseable {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.HistoryServerOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.history.FsJobArchivist;
 import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
@@ -52,6 +53,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
@@ -122,9 +124,13 @@ public class HistoryServerTest extends TestLogger {
 
 		CountDownLatch numExpectedArchivedJobs = new CountDownLatch(numJobs + numLegacyJobs);
 
-		Configuration historyServerConfig = createTestConfiguration();
+		Configuration historyServerConfig = createTestConfiguration(false);
 
-		HistoryServer hs = new HistoryServer(historyServerConfig, numExpectedArchivedJobs);
+		HistoryServer hs = new HistoryServer(historyServerConfig, (event) -> {
+			if (event.getType() == HistoryServerArchiveFetcher.ArchiveEventType.CREATED) {
+				numExpectedArchivedJobs.countDown();
+			}
+		});
 
 		try {
 			hs.start();
@@ -132,7 +138,75 @@ public class HistoryServerTest extends TestLogger {
 			numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS);
 
 			Assert.assertEquals(numJobs + numLegacyJobs, getJobsOverview(baseUrl).getJobs().size());
+		} finally {
+			hs.stop();
+		}
+	}
 
+	@Test
+	public void testCleanExpiredJob() throws Exception {
+		runArchiveExpirationTest(true);
+	}
+
+	@Test
+	public void testRemainExpiredJob() throws Exception {
+		runArchiveExpirationTest(false);
+	}
+
+	private void runArchiveExpirationTest(boolean cleanupExpiredJobs) throws Exception {
+		int numExpiredJobs = cleanupExpiredJobs ? 1 : 0;
+		int numJobs = 3;
+		for (int x = 0; x < numJobs; x++) {
+			runJob();
+		}
+		waitForArchivesCreation(numJobs);
+
+		CountDownLatch numExpectedArchivedJobs = new CountDownLatch(numJobs);
+		CountDownLatch numExpectedExpiredJobs = new CountDownLatch(numExpiredJobs);
+
+		Configuration historyServerConfig = createTestConfiguration(cleanupExpiredJobs);
+
+		HistoryServer hs =
+			new HistoryServer(
+				historyServerConfig,
+				(event) -> {
+					switch (event.getType()){
+						case CREATED:
+							numExpectedArchivedJobs.countDown();
+							break;
+						case DELETED:
+							numExpectedExpiredJobs.countDown();
+							break;
+					}
+				});
+
+		try {
+			hs.start();
+			String baseUrl = "http://localhost:" + hs.getWebPort();
+			numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS);
+
+			Collection<JobDetails> jobs = getJobsOverview(baseUrl).getJobs();
+			Assert.assertEquals(numJobs, jobs.size());
+
+			String jobIdToDelete = jobs.stream()
+				.findFirst()
+				.map(JobDetails::getJobId)
+				.map(JobID::toString)
+				.orElseThrow(() -> new IllegalStateException("Expected at least one existing job"));
+
+			// delete one archive from jm
+			Files.deleteIfExists(jmDirectory.toPath().resolve(jobIdToDelete));
+
+			numExpectedExpiredJobs.await(10L, TimeUnit.SECONDS);
+
+			// check that archive is present in hs
+			Collection<JobDetails> jobsAfterDeletion = getJobsOverview(baseUrl).getJobs();
+			Assert.assertEquals(numJobs - numExpiredJobs, jobsAfterDeletion.size());
+			Assert.assertEquals(1 - numExpiredJobs, jobsAfterDeletion.stream()
+				.map(JobDetails::getJobId)
+				.map(JobID::toString)
+				.filter(jobId -> jobId.equals(jobIdToDelete))
+				.count());
 		} finally {
 			hs.stop();
 		}
@@ -147,17 +221,19 @@ public class HistoryServerTest extends TestLogger {
 		}
 	}
 
-	private Configuration createTestConfiguration() {
+	private Configuration createTestConfiguration(boolean cleanupExpiredJobs) {
 		Configuration historyServerConfig = new Configuration();
 		historyServerConfig.setString(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_DIRS, jmDirectory.toURI().toString());
 		historyServerConfig.setString(HistoryServerOptions.HISTORY_SERVER_WEB_DIR, hsDirectory.getAbsolutePath());
 		historyServerConfig.setLong(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL, 100L);
 
+		historyServerConfig.setBoolean(HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS, cleanupExpiredJobs);
+
 		historyServerConfig.setInteger(HistoryServerOptions.HISTORY_SERVER_WEB_PORT, 0);
 		return historyServerConfig;
 	}
 
-	private MultipleJobsDetails getJobsOverview(String baseUrl) throws Exception {
+	private static MultipleJobsDetails getJobsOverview(String baseUrl) throws Exception {
 		String response = getFromHTTP(baseUrl + JobsOverviewHeaders.URL);
 		return OBJECT_MAPPER.readValue(response, MultipleJobsDetails.class);
 	}
@@ -169,7 +245,7 @@ public class HistoryServerTest extends TestLogger {
 		env.execute();
 	}
 
-	public static String getFromHTTP(String url) throws Exception {
+	static String getFromHTTP(String url) throws Exception {
 		URL u = new URL(url);
 		HttpURLConnection connection = (HttpURLConnection) u.openConnection();
 		connection.setConnectTimeout(100000);

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.history.FsJobArchivist;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
+import org.apache.flink.runtime.rest.messages.DashboardConfiguration;
+import org.apache.flink.runtime.rest.messages.DashboardConfigurationHeaders;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -35,6 +37,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.commons.io.IOUtils;
@@ -70,7 +73,8 @@ public class HistoryServerTest extends TestLogger {
 	private static final JsonFactory JACKSON_FACTORY = new JsonFactory()
 		.enable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
 		.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
-	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+		.enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES);
 
 	@Rule
 	public final TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -138,6 +142,9 @@ public class HistoryServerTest extends TestLogger {
 			numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS);
 
 			Assert.assertEquals(numJobs + numLegacyJobs, getJobsOverview(baseUrl).getJobs().size());
+
+			// checks whether the dashboard configuration contains all expected fields
+			getDashboardConfiguration(baseUrl);
 		} finally {
 			hs.stop();
 		}
@@ -231,6 +238,12 @@ public class HistoryServerTest extends TestLogger {
 
 		historyServerConfig.setInteger(HistoryServerOptions.HISTORY_SERVER_WEB_PORT, 0);
 		return historyServerConfig;
+	}
+
+	private static DashboardConfiguration getDashboardConfiguration(String baseUrl) throws Exception {
+		String response = getFromHTTP(baseUrl + DashboardConfigurationHeaders.INSTANCE.getTargetRestEndpointURL());
+		return OBJECT_MAPPER.readValue(response, DashboardConfiguration.class);
+
 	}
 
 	private static MultipleJobsDetails getJobsOverview(String baseUrl) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/DashboardConfigurationHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/DashboardConfigurationHeaders.java
@@ -28,7 +28,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
  */
 public final class DashboardConfigurationHeaders implements MessageHeaders<EmptyRequestBody, DashboardConfiguration, EmptyMessageParameters> {
 
-	private static final DashboardConfigurationHeaders INSTANCE = new DashboardConfigurationHeaders();
+	public static final DashboardConfigurationHeaders INSTANCE = new DashboardConfigurationHeaders();
 
 	// make the constructor private since we want it to be a singleton
 	private DashboardConfigurationHeaders() {}


### PR DESCRIPTION
This PR gets three commits from master branch, as it solves the blocker we had starting the history server with flink-1.9. 

I filed the jira ticket for the history server bug: FLINK-15085. 
That change depends on FLINK-14169. So I cherry-picked the corresponding commits
