### PR TITLE
Enable support for viewfs 

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableWriter.CommitRecoverable;
 import org.apache.flink.core.fs.RecoverableWriter.ResumeRecoverable;
+import org.apache.flink.runtime.util.HadoopUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
@@ -34,6 +35,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.util.VersionInfo;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -174,7 +176,7 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 	}
 
 	private static void ensureTruncateInitialized() throws FlinkRuntimeException {
-		if (truncateHandle == null) {
+		if (HadoopUtils.isMinHadoopVersion(2, 7) && truncateHandle == null) {
 			Method truncateMethod;
 			try {
 				truncateMethod = FileSystem.class.getMethod("truncate", Path.class, long.class);
@@ -192,6 +194,10 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 	}
 
 	private static boolean truncate(final FileSystem hadoopFs, final Path file, final long length) throws IOException {
+		if (!HadoopUtils.isMinHadoopVersion(2, 7)) {
+			throw new IllegalStateException("Truncation is not available in hadoop version < 2.7 , You are on Hadoop " + VersionInfo.getVersion());
+		}
+
 		if (truncateHandle != null) {
 			try {
 				return (Boolean) truncateHandle.invoke(hadoopFs, file, length);

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
@@ -27,6 +27,10 @@ import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.util.HadoopUtils;
 
+import org.apache.hadoop.util.VersionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.UUID;
 
@@ -40,6 +44,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class HadoopRecoverableWriter implements RecoverableWriter {
 
+	private static final Logger LOG = LoggerFactory.getLogger(HadoopRecoverableWriter.class);
+
 	/** The Hadoop file system on which the writer operates. */
 	private final org.apache.hadoop.fs.FileSystem fs;
 
@@ -50,12 +56,17 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 	public HadoopRecoverableWriter(org.apache.hadoop.fs.FileSystem fs) {
 		this.fs = checkNotNull(fs);
 
-		// This writer is only supported on a subset of file systems, and on
-		// specific versions. We check these schemes and versions eagerly for
-		// better error messages.
-		if (!"hdfs".equalsIgnoreCase(fs.getScheme()) || !HadoopUtils.isMinHadoopVersion(2, 7)) {
+		// This writer is only supported on a subset of file systems
+		if (!"hdfs".equalsIgnoreCase(fs.getScheme())) {
 			throw new UnsupportedOperationException(
 					"Recoverable writers on Hadoop are only supported for HDFS and for Hadoop version 2.7 or newer");
+		}
+
+		// Part of functionality depends on specific versions. We check these schemes and versions eagerly for
+		// better error messages.
+		if (!HadoopUtils.isMinHadoopVersion(2, 7)) {
+			LOG.warn("WARNING: You are running on hadoop version " + VersionInfo.getVersion() + "." +
+					" If your RollingPolicy does not roll on every checkpoint/savepoint, the StreamingFileSink will throw an exception upon recovery.");
 		}
 	}
 

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
@@ -57,7 +57,7 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 		this.fs = checkNotNull(fs);
 
 		// This writer is only supported on a subset of file systems
-		if (!"hdfs".equalsIgnoreCase(fs.getScheme())) {
+		if (!("hdfs".equalsIgnoreCase(fs.getScheme()) || "viewfs".equalsIgnoreCase(fs.getScheme()))) {
 			throw new UnsupportedOperationException(
 					"Recoverable writers on Hadoop are only supported for HDFS and for Hadoop version 2.7 or newer");
 		}


### PR DESCRIPTION
## What is the purpose of the change

[[FLINK-14170]](https://issues.apache.org/jira/browse/FLINK-14170) introduced Hadoop version check to support older hadoop versions. However the check only included "hdfs" scheme but not "viewfs".
We are using StreamingFileSink to write data to our federated cluster and we are using cdh-2.6 hadoop version and we are hit with exception:

java.lang.UnsupportedOperationException: Recoverable writers on Hadoop are only supported for HDFS and for Hadoop version 2.7 or newer
	
## Brief change log

Removed the hadoop < 2.7 version check if scheme is viewfs in HadoopRecoverableWriter

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 