### PR TITLE
Add Labels to the mesos task info

### DIFF
--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -63,6 +63,11 @@
             <td>Optional value to define the TaskManager’s hostname. The pattern _TASK_ is replaced by the actual id of the Mesos task. This can be used to configure the TaskManager to use Mesos DNS (e.g. _TASK_.flink-service.mesos) for name lookups.</td>
         </tr>
         <tr>
+            <td><h5>mesos.resourcemanager.tasks.labels</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>The labels to be set for TaskManager. Specified as key:value pairs separated by commas. For example, key1:value1,key2:value2.</td>
+        </tr>
+        <tr>
             <td><h5>mesos.resourcemanager.tasks.mem</h5></td>
             <td style="word-wrap: break-word;">1024</td>
             <td>Memory to assign to the Mesos workers in MB.</td>
@@ -78,9 +83,9 @@
             <td>A comma separated list of URIs of custom artifacts to be downloaded into the sandbox of Mesos workers.</td>
         </tr>
         <tr>
-            <td><h5>mesos.resourcemanager.tasks.labels</h5></td>
+            <td><h5>mesos.resourcemanager.tasks.user</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>A comma separated key value pairs of labels to be set on taskmanager. For example, key1:value1,key2:value2</td>
+            <td>The Unix user to be used to run the tasks in mesos containers.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>

--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -78,6 +78,11 @@
             <td>A comma separated list of URIs of custom artifacts to be downloaded into the sandbox of Mesos workers.</td>
         </tr>
         <tr>
+            <td><h5>mesos.resourcemanager.tasks.labels</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>A comma separated key value pairs of labels to be set on taskmanager. For example, key1:value1,key2:value2</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>The number of parallel operator or user function instances that a single TaskManager can run. If this value is larger than 1, a single TaskManager takes multiple instances of a function or operator. That way, the TaskManager can utilize multiple CPU cores, but at the same time, the available memory is divided between the different operator or function instances. This value is typically proportional to the number of physical CPU cores that the TaskManager's machine has (e.g., equal to the number of cores, or half the number of cores).</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
@@ -19,6 +19,12 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.description.Description;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -30,21 +36,32 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * // simple string-valued option with a default value
  * ConfigOption<String> tempDirs = ConfigOptions
  *     .key("tmp.dir")
+ *     .stringType()
  *     .defaultValue("/tmp");
  *
  * // simple integer-valued option with a default value
  * ConfigOption<Integer> parallelism = ConfigOptions
  *     .key("application.parallelism")
+ *     .intType()
  *     .defaultValue(100);
+ *
+ * // option of list of integers with a default value
+ * ConfigOption<Integer> parallelism = ConfigOptions
+ *     .key("application.ports")
+ *     .intType()
+ *     .asList()
+ *     .defaultValue(8000, 8001, 8002);
  *
  * // option with no default value
  * ConfigOption<String> userName = ConfigOptions
  *     .key("user.name")
+ *     .stringType()
  *     .noDefaultValue();
  *
  * // option with deprecated keys to check
  * ConfigOption<Double> threshold = ConfigOptions
  *     .key("cpu.utilization.threshold")
+ *     .doubleType()
  *     .defaultValue(0.9).
  *     .withDeprecatedKeys("cpu.threshold");
  * }</pre>
@@ -83,6 +100,79 @@ public class ConfigOptions {
 		}
 
 		/**
+		 * Defines that the value of the option should be of {@link Boolean} type.
+		 */
+		public TypedConfigOptionBuilder<Boolean> booleanType() {
+			return new TypedConfigOptionBuilder<>(key, Boolean.class);
+		}
+
+		/**
+		 * Defines that the value of the option should be of {@link Integer} type.
+		 */
+		public TypedConfigOptionBuilder<Integer> intType() {
+			return new TypedConfigOptionBuilder<>(key, Integer.class);
+		}
+
+		/**
+		 * Defines that the value of the option should be of {@link Long} type.
+		 */
+		public TypedConfigOptionBuilder<Long> longType() {
+			return new TypedConfigOptionBuilder<>(key, Long.class);
+		}
+
+		/**
+		 * Defines that the value of the option should be of {@link Float} type.
+		 */
+		public TypedConfigOptionBuilder<Float> floatType() {
+			return new TypedConfigOptionBuilder<>(key, Float.class);
+		}
+
+		/**
+		 * Defines that the value of the option should be of {@link Double} type.
+		 */
+		public TypedConfigOptionBuilder<Double> doubleType() {
+			return new TypedConfigOptionBuilder<>(key, Double.class);
+		}
+
+		/**
+		 * Defines that the value of the option should be of {@link String} type.
+		 */
+		public TypedConfigOptionBuilder<String> stringType() {
+			return new TypedConfigOptionBuilder<>(key, String.class);
+		}
+
+		/**
+		 * Defines that the value of the option should be of {@link Duration} type.
+		 */
+		public TypedConfigOptionBuilder<Duration> durationType() {
+			return new TypedConfigOptionBuilder<>(key, Duration.class);
+		}
+
+		/**
+		 * Defines that the value of the option should be of {@link MemorySize} type.
+		 */
+		public TypedConfigOptionBuilder<MemorySize> memoryType() {
+			return new TypedConfigOptionBuilder<>(key, MemorySize.class);
+		}
+
+		/**
+		 * Defines that the value of the option should be of {@link Enum} type.
+		 *
+		 * @param enumClass Concrete type of the expected enum.
+		 */
+		public <T extends Enum<T>> TypedConfigOptionBuilder<T> enumType(Class<T> enumClass) {
+			return new TypedConfigOptionBuilder<>(key, enumClass);
+		}
+
+		/**
+		 * Defines that the value of the option should be a set of properties, which can be represented as
+		 * {@code Map<String, String>}.
+		 */
+		public TypedConfigOptionBuilder<Map<String, String>> mapType() {
+			return new TypedConfigOptionBuilder<>(key, Map.class);
+		}
+
+		/**
 		 * Creates a ConfigOption with the given default value.
 		 *
 		 * <p>This method does not accept "null". For options with no default value, choose
@@ -91,10 +181,17 @@ public class ConfigOptions {
 		 * @param value The default value for the config option
 		 * @param <T> The type of the default value.
 		 * @return The config option with the default value.
+		 * @deprecated define the type explicitly first with one of the intType(), stringType(), etc.
 		 */
+		@Deprecated
 		public <T> ConfigOption<T> defaultValue(T value) {
 			checkNotNull(value);
-			return new ConfigOption<>(key, value);
+			return new ConfigOption<>(
+				key,
+				value.getClass(),
+				ConfigOption.EMPTY_DESCRIPTION,
+				value,
+				false);
 		}
 
 		/**
@@ -103,11 +200,115 @@ public class ConfigOptions {
 		 * default value.
 		 *
 		 * @return The created ConfigOption.
+		 * @deprecated define the type explicitly first with one of the intType(), stringType(), etc.
 		 */
+		@Deprecated
 		public ConfigOption<String> noDefaultValue() {
-			return new ConfigOption<>(key, null);
+			return new ConfigOption<>(
+				key,
+				String.class,
+				ConfigOption.EMPTY_DESCRIPTION,
+				null,
+				false);
 		}
 	}
+
+	/**
+	 * Builder for {@link ConfigOption} with a defined atomic type.
+	 *
+	 * @param <T> atomic type of the option
+	 */
+	public static class TypedConfigOptionBuilder<T> {
+		private final String key;
+		private final Class clazz;
+
+		TypedConfigOptionBuilder(String key, Class clazz) {
+			this.key = key;
+			this.clazz = clazz;
+		}
+
+		/**
+		 * Defines that the option's type should be a list of previously defined atomic type.
+		 */
+		public ListConfigOptionBuilder<T> asList() {
+			return new ListConfigOptionBuilder<>(key, clazz);
+		}
+
+		/**
+		 * Creates a ConfigOption with the given default value.
+		 *
+		 * @param value The default value for the config option
+		 * @return The config option with the default value.
+		 */
+		public ConfigOption<T> defaultValue(T value) {
+			return new ConfigOption<>(
+				key,
+				clazz,
+				ConfigOption.EMPTY_DESCRIPTION,
+				value,
+				false);
+		}
+
+		/**
+		 * Creates a ConfigOption without a default value.
+		 *
+		 * @return The config option without a default value.
+		 */
+		public ConfigOption<T> noDefaultValue() {
+			return new ConfigOption<T>(
+				key,
+				clazz,
+				Description.builder().text("").build(),
+				null,
+				false);
+		}
+	}
+
+	/**
+	 * Builder for {@link ConfigOption} of list of type T.
+	 *
+	 * @param <T> atomic type of the option
+	 */
+	public static class ListConfigOptionBuilder<T> {
+		private final String key;
+		private final Class clazz;
+
+		ListConfigOptionBuilder(String key, Class clazz) {
+			this.key = key;
+			this.clazz = clazz;
+		}
+
+		/**
+		 * Creates a ConfigOption with the given default value.
+		 *
+		 * @param values The list of default values for the config option
+		 * @return The config option with the default value.
+		 */
+		@SafeVarargs
+		public final ConfigOption<List<T>> defaultValues(T... values) {
+			return new ConfigOption<>(
+				key,
+				clazz,
+				ConfigOption.EMPTY_DESCRIPTION,
+				Arrays.asList(values),
+				true);
+		}
+
+		/**
+		 * Creates a ConfigOption without a default value.
+		 *
+		 * @return The config option without a default value.
+		 */
+		public ConfigOption<List<T>> noDefaultValue() {
+			return new ConfigOption<>(
+				key,
+				clazz,
+				ConfigOption.EMPTY_DESCRIPTION,
+				null,
+				true);
+		}
+	}
+
 
 	// ------------------------------------------------------------------------
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -25,18 +25,23 @@ import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.types.StringValue;
+import org.apache.flink.util.TimeUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -45,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Public
 public class Configuration extends ExecutionConfig.GlobalJobParameters
-		implements IOReadableWritable, java.io.Serializable, Cloneable {
+		implements IOReadableWritable, java.io.Serializable, Cloneable, ReadableConfig, WritableConfig {
 
 	private static final long serialVersionUID = 1L;
 
@@ -96,18 +101,21 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 * @return The value associated with the given key, or the default value, if to entry for the key exists.
 	 */
 	@SuppressWarnings("unchecked")
-	public <T> Class<T> getClass(String key, Class<? extends T> defaultValue, ClassLoader classLoader) throws ClassNotFoundException {
-		Object o = getRawValue(key);
-		if (o == null) {
+	public <T> Class<T> getClass(
+			String key,
+			Class<? extends T> defaultValue,
+			ClassLoader classLoader) throws ClassNotFoundException {
+		Optional<Object> o = getRawValue(key);
+		if (!o.isPresent()) {
 			return (Class<T>) defaultValue;
 		}
 
-		if (o.getClass() == String.class) {
-			return (Class<T>) Class.forName((String) o, true, classLoader);
+		if (o.get().getClass() == String.class) {
+			return (Class<T>) Class.forName((String) o.get(), true, classLoader);
 		}
 
-		LOG.warn("Configuration cannot evaluate value " + o + " as a class name");
-		return (Class<T>) defaultValue;
+		throw new IllegalArgumentException(
+			"Configuration cannot evaluate object of class " + o.get().getClass() + " as a class name");
 	}
 
 	/**
@@ -130,14 +138,13 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 * @param defaultValue
 	 *        the default value which is returned in case there is no value associated with the given key
 	 * @return the (default) value associated with the given key
+	 * @deprecated use {@link #getString(ConfigOption, String)} or {@link #getOptional(ConfigOption)}
 	 */
+	@Deprecated
 	public String getString(String key, String defaultValue) {
-		Object o = getRawValue(key);
-		if (o == null) {
-			return defaultValue;
-		} else {
-			return o.toString();
-		}
+		return getRawValue(key)
+			.map(this::convertToString)
+			.orElse(defaultValue);
 	}
 
 	/**
@@ -148,8 +155,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public String getString(ConfigOption<String> configOption) {
-		Object o = getValueOrDefaultFromOption(configOption);
-		return o == null ? null : o.toString();
+		return getOptional(configOption)
+			.orElseGet(configOption::defaultValue);
 	}
 
 	/**
@@ -162,8 +169,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public String getString(ConfigOption<String> configOption, String overrideDefault) {
-		Object o = getRawValueFromOption(configOption);
-		return o == null ? overrideDefault : o.toString();
+		return getOptional(configOption)
+			.orElse(overrideDefault);
 	}
 
 	/**
@@ -200,14 +207,13 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 * @param defaultValue
 	 *        the default value which is returned in case there is no value associated with the given key
 	 * @return the (default) value associated with the given key
+	 * @deprecated use {@link #getInteger(ConfigOption, int)} or {@link #getOptional(ConfigOption)}
 	 */
+	@Deprecated
 	public int getInteger(String key, int defaultValue) {
-		Object o = getRawValue(key);
-		if (o == null) {
-			return defaultValue;
-		}
-
-		return convertToInt(o, defaultValue);
+		return getRawValue(key)
+			.map(this::convertToInt)
+			.orElse(defaultValue);
 	}
 
 	/**
@@ -218,8 +224,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public int getInteger(ConfigOption<Integer> configOption) {
-		Object o = getValueOrDefaultFromOption(configOption);
-		return convertToInt(o, configOption.defaultValue());
+		return getOptional(configOption)
+			.orElseGet(configOption::defaultValue);
 	}
 
 	/**
@@ -233,11 +239,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public int getInteger(ConfigOption<Integer> configOption, int overrideDefault) {
-		Object o = getRawValueFromOption(configOption);
-		if (o == null) {
-			return overrideDefault;
-		}
-		return convertToInt(o, configOption.defaultValue());
+		return getOptional(configOption)
+			.orElse(overrideDefault);
 	}
 
 	/**
@@ -274,14 +277,13 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 * @param defaultValue
 	 *        the default value which is returned in case there is no value associated with the given key
 	 * @return the (default) value associated with the given key
+	 * @deprecated use {@link #getLong(ConfigOption, long)} or {@link #getOptional(ConfigOption)}
 	 */
+	@Deprecated
 	public long getLong(String key, long defaultValue) {
-		Object o = getRawValue(key);
-		if (o == null) {
-			return defaultValue;
-		}
-
-		return convertToLong(o, defaultValue);
+		return getRawValue(key)
+			.map(this::convertToLong)
+			.orElse(defaultValue);
 	}
 
 	/**
@@ -292,8 +294,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public long getLong(ConfigOption<Long> configOption) {
-		Object o = getValueOrDefaultFromOption(configOption);
-		return convertToLong(o, configOption.defaultValue());
+		return getOptional(configOption)
+			.orElseGet(configOption::defaultValue);
 	}
 
 	/**
@@ -307,11 +309,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public long getLong(ConfigOption<Long> configOption, long overrideDefault) {
-		Object o = getRawValueFromOption(configOption);
-		if (o == null) {
-			return overrideDefault;
-		}
-		return convertToLong(o, configOption.defaultValue());
+		return getOptional(configOption)
+			.orElse(overrideDefault);
 	}
 
 	/**
@@ -348,14 +347,13 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 * @param defaultValue
 	 *        the default value which is returned in case there is no value associated with the given key
 	 * @return the (default) value associated with the given key
+	 * @deprecated use {@link #getBoolean(ConfigOption, boolean)} or {@link #getOptional(ConfigOption)}
 	 */
+	@Deprecated
 	public boolean getBoolean(String key, boolean defaultValue) {
-		Object o = getRawValue(key);
-		if (o == null) {
-			return defaultValue;
-		}
-
-		return convertToBoolean(o);
+		return getRawValue(key)
+			.map(this::convertToBoolean)
+			.orElse(defaultValue);
 	}
 
 	/**
@@ -366,8 +364,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public boolean getBoolean(ConfigOption<Boolean> configOption) {
-		Object o = getValueOrDefaultFromOption(configOption);
-		return convertToBoolean(o);
+		return getOptional(configOption)
+			.orElseGet(configOption::defaultValue);
 	}
 
 	/**
@@ -381,11 +379,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public boolean getBoolean(ConfigOption<Boolean> configOption, boolean overrideDefault) {
-		Object o = getRawValueFromOption(configOption);
-		if (o == null) {
-			return overrideDefault;
-		}
-		return convertToBoolean(o);
+		return getOptional(configOption)
+			.orElse(overrideDefault);
 	}
 
 	/**
@@ -422,14 +417,13 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 * @param defaultValue
 	 *        the default value which is returned in case there is no value associated with the given key
 	 * @return the (default) value associated with the given key
+	 * @deprecated use {@link #getFloat(ConfigOption, float)} or {@link #getOptional(ConfigOption)}
 	 */
+	@Deprecated
 	public float getFloat(String key, float defaultValue) {
-		Object o = getRawValue(key);
-		if (o == null) {
-			return defaultValue;
-		}
-
-		return convertToFloat(o, defaultValue);
+		return getRawValue(key)
+			.map(this::convertToFloat)
+			.orElse(defaultValue);
 	}
 
 	/**
@@ -440,8 +434,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public float getFloat(ConfigOption<Float> configOption) {
-		Object o = getValueOrDefaultFromOption(configOption);
-		return convertToFloat(o, configOption.defaultValue());
+		return getOptional(configOption)
+			.orElseGet(configOption::defaultValue);
 	}
 
 	/**
@@ -455,11 +449,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public float getFloat(ConfigOption<Float> configOption, float overrideDefault) {
-		Object o = getRawValueFromOption(configOption);
-		if (o == null) {
-			return overrideDefault;
-		}
-		return convertToFloat(o, configOption.defaultValue());
+		return getOptional(configOption)
+			.orElse(overrideDefault);
 	}
 
 	/**
@@ -496,14 +487,13 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 * @param defaultValue
 	 *        the default value which is returned in case there is no value associated with the given key
 	 * @return the (default) value associated with the given key
+	 * @deprecated use {@link #getDouble(ConfigOption, double)} or {@link #getOptional(ConfigOption)}
 	 */
+	@Deprecated
 	public double getDouble(String key, double defaultValue) {
-		Object o = getRawValue(key);
-		if (o == null) {
-			return defaultValue;
-		}
-
-		return convertToDouble(o, defaultValue);
+		return getRawValue(key)
+			.map(this::convertToDouble)
+			.orElse(defaultValue);
 	}
 
 	/**
@@ -514,8 +504,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public double getDouble(ConfigOption<Double> configOption) {
-		Object o = getValueOrDefaultFromOption(configOption);
-		return convertToDouble(o, configOption.defaultValue());
+		return getOptional(configOption)
+			.orElseGet(configOption::defaultValue);
 	}
 
 	/**
@@ -529,11 +519,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public double getDouble(ConfigOption<Double> configOption, double overrideDefault) {
-		Object o = getRawValueFromOption(configOption);
-		if (o == null) {
-			return overrideDefault;
-		}
-		return convertToDouble(o, configOption.defaultValue());
+		return getOptional(configOption)
+			.orElse(overrideDefault);
 	}
 
 	/**
@@ -571,20 +558,17 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 *        The default value which is returned in case there is no value associated with the given key.
 	 * @return the (default) value associated with the given key.
 	 */
-	@SuppressWarnings("EqualsBetweenInconvertibleTypes")
 	public byte[] getBytes(String key, byte[] defaultValue) {
-
-		Object o = getRawValue(key);
-		if (o == null) {
-			return defaultValue;
-		}
-		else if (o.getClass().equals(byte[].class)) {
-			return (byte[]) o;
-		}
-		else {
-			LOG.warn("Configuration cannot evaluate value {} as a byte[] value", o);
-			return defaultValue;
-		}
+		return getRawValue(key).map(o -> {
+				if (o.getClass().equals(byte[].class)) {
+					return (byte[]) o;
+				} else {
+					throw new IllegalArgumentException(String.format(
+						"Configuration cannot evaluate value %s as a byte[] value",
+						o));
+				}
+			}
+		).orElse(defaultValue);
 	}
 
 	/**
@@ -607,8 +591,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 */
 	@PublicEvolving
 	public String getValue(ConfigOption<?> configOption) {
-		Object o = getValueOrDefaultFromOption(configOption);
-		return o == null ? null : o.toString();
+		return Optional.ofNullable(getRawValueFromOption(configOption).orElseGet(configOption::defaultValue))
+			.map(String::valueOf)
+			.orElse(null);
 	}
 
 	/**
@@ -626,15 +611,17 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 		checkNotNull(enumClass, "enumClass must not be null");
 		checkNotNull(configOption, "configOption must not be null");
 
-		final String configValue = getString(configOption);
+		Object rawValue = getRawValueFromOption(configOption)
+			.orElseGet(configOption::defaultValue);
 		try {
-			return Enum.valueOf(enumClass, configValue.toUpperCase(Locale.ROOT));
-		} catch (final IllegalArgumentException | NullPointerException e) {
-			final String errorMessage = String.format("Value for config option %s must be one of %s (was %s)",
+			return convertToEnum(rawValue, enumClass);
+		} catch (IllegalArgumentException ex) {
+			final String errorMessage = String.format(
+				"Value for config option %s must be one of %s (was %s)",
 				configOption.key(),
 				Arrays.toString(enumClass.getEnumConstants()),
-				configValue);
-			throw new IllegalArgumentException(errorMessage, e);
+				rawValue);
+			throw new IllegalArgumentException(errorMessage);
 		}
 	}
 
@@ -745,6 +732,36 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 		}
 	}
 
+	@Override
+	public <T> T get(ConfigOption<T> option) {
+		return getOptional(option).orElseGet(option::defaultValue);
+	}
+
+	@Override
+	public <T> Optional<T> getOptional(ConfigOption<T> option) {
+		Optional<Object> rawValue = getRawValueFromOption(option);
+		Class clazz = option.getClazz();
+
+		try {
+			if (option.isList()) {
+				return rawValue.map(v -> convertToList(v, clazz));
+			} else {
+				return rawValue.map(v -> convertValue(v, clazz));
+			}
+		} catch (Exception e) {
+			throw new IllegalArgumentException(String.format(
+				"Could not parse value '%s' for key '%s'.",
+				rawValue.map(Object::toString).orElse(""),
+				option.key()), e);
+		}
+	}
+
+	@Override
+	public <T> WritableConfig set(ConfigOption<T> option, T value) {
+		setValueInternal(option.key(), value);
+		return this;
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	@Override
@@ -799,41 +816,36 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 		}
 	}
 
-	private Object getRawValue(String key) {
+	private Optional<Object> getRawValue(String key) {
 		if (key == null) {
 			throw new NullPointerException("Key must not be null.");
 		}
 
 		synchronized (this.confData) {
-			return this.confData.get(key);
+			return Optional.ofNullable(this.confData.get(key));
 		}
 	}
 
-	private Object getRawValueFromOption(ConfigOption<?> configOption) {
+	private Optional<Object> getRawValueFromOption(ConfigOption<?> configOption) {
 		// first try the current key
-		Object o = getRawValue(configOption.key());
+		Optional<Object> o = getRawValue(configOption.key());
 
-		if (o != null) {
+		if (o.isPresent()) {
 			// found a value for the current proper key
 			return o;
 		}
 		else if (configOption.hasFallbackKeys()) {
 			// try the deprecated keys
 			for (FallbackKey fallbackKey : configOption.fallbackKeys()) {
-				Object oo = getRawValue(fallbackKey.getKey());
-				if (oo != null) {
+				Optional<Object> oo = getRawValue(fallbackKey.getKey());
+				if (oo.isPresent()) {
 					loggingFallback(fallbackKey, configOption);
 					return oo;
 				}
 			}
 		}
 
-		return null;
-	}
-
-	private Object getValueOrDefaultFromOption(ConfigOption<?> configOption) {
-		Object o = getRawValueFromOption(configOption);
-		return o != null ? o : configOption.defaultValue();
+		return Optional.empty();
 	}
 
 	private void loggingFallback(FallbackKey fallbackKey, ConfigOption<?> configOption) {
@@ -850,99 +862,173 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	//  Type conversion
 	// --------------------------------------------------------------------------------------------
 
-	private int convertToInt(Object o, int defaultValue) {
+	@SuppressWarnings("unchecked")
+	private <T> T convertValue(Object rawValue, Class clazz) {
+		if (Integer.class.equals(clazz)) {
+			return (T) convertToInt(rawValue);
+		} else if (Long.class.equals(clazz)) {
+			return (T) convertToLong(rawValue);
+		} else if (Boolean.class.equals(clazz)) {
+			return (T) convertToBoolean(rawValue);
+		} else if (Float.class.equals(clazz)) {
+			return (T) convertToFloat(rawValue);
+		} else if (Double.class.equals(clazz)) {
+			return (T) convertToDouble(rawValue);
+		} else if (String.class.equals(clazz)) {
+			return (T) convertToString(rawValue);
+		} else if (clazz.isEnum()) {
+			return (T) convertToEnum(rawValue, clazz);
+		} else if (clazz == Duration.class) {
+			return (T) convertToDuration(rawValue);
+		} else if (clazz == MemorySize.class) {
+			return (T) convertToMemorySize(rawValue);
+		} else if (clazz == Map.class) {
+			return (T) convertToProperties(rawValue);
+		}
+
+		throw new IllegalArgumentException("Unsupported type: " + clazz);
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> T convertToList(Object rawValue, Class atomicClass) {
+		if (rawValue instanceof List) {
+			return (T) rawValue;
+		} else {
+			return (T) StructuredOptionsSplitter.splitEscaped(rawValue.toString(), ';').stream()
+				.map(s -> convertValue(s, atomicClass))
+				.collect(Collectors.toList());
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, String> convertToProperties(Object o) {
+		if (o instanceof Map) {
+			return (Map<String, String>) o;
+		} else {
+			List<String> listOfRawProperties = StructuredOptionsSplitter.splitEscaped(o.toString(), ',');
+			return listOfRawProperties.stream()
+				.map(s -> StructuredOptionsSplitter.splitEscaped(s, ':'))
+				.map(pair -> {
+					if (pair.size() != 2) {
+						throw new IllegalArgumentException("Could not parse pair in the map " + pair);
+					}
+
+					return pair;
+				})
+				.collect(Collectors.toMap(
+					a -> a.get(0),
+					a -> a.get(1)
+				));
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private <E extends Enum<E>> E convertToEnum(Object o, Class<E> clazz) {
+		if (o.getClass().equals(clazz)) {
+			return (E) o;
+		}
+
+		return Enum.valueOf(clazz, o.toString().toUpperCase(Locale.ROOT));
+	}
+
+	private Duration convertToDuration(Object o) {
+		if (o.getClass() == Duration.class) {
+			return (Duration) o;
+		}
+
+		return TimeUtils.parseDuration(o.toString());
+	}
+
+	private MemorySize convertToMemorySize(Object o) {
+		if (o.getClass() == MemorySize.class) {
+			return (MemorySize) o;
+		}
+
+		return MemorySize.parse(o.toString());
+	}
+
+	private String convertToString(Object o) {
+		if (o.getClass() == String.class) {
+			return (String) o;
+		} else if (o.getClass() == Duration.class) {
+			Duration duration = (Duration) o;
+			return String.format("%d ns", duration.toNanos());
+		}
+
+		return o.toString();
+	}
+
+	private Integer convertToInt(Object o) {
 		if (o.getClass() == Integer.class) {
 			return (Integer) o;
-		}
-		else if (o.getClass() == Long.class) {
+		} else if (o.getClass() == Long.class) {
 			long value = (Long) o;
 			if (value <= Integer.MAX_VALUE && value >= Integer.MIN_VALUE) {
 				return (int) value;
 			} else {
-				LOG.warn("Configuration value {} overflows/underflows the integer type.", value);
-				return defaultValue;
+				throw new IllegalArgumentException(String.format(
+					"Configuration value %s overflows/underflows the integer type.",
+					value));
 			}
 		}
-		else {
-			try {
-				return Integer.parseInt(o.toString());
-			}
-			catch (NumberFormatException e) {
-				LOG.warn("Configuration cannot evaluate value {} as an integer number", o);
-				return defaultValue;
-			}
-		}
+
+		return Integer.parseInt(o.toString());
 	}
 
-	private long convertToLong(Object o, long defaultValue) {
+	private Long convertToLong(Object o) {
 		if (o.getClass() == Long.class) {
 			return (Long) o;
-		}
-		else if (o.getClass() == Integer.class) {
+		} else if (o.getClass() == Integer.class) {
 			return ((Integer) o).longValue();
 		}
-		else {
-			try {
-				return Long.parseLong(o.toString());
-			}
-			catch (NumberFormatException e) {
-				LOG.warn("Configuration cannot evaluate value " + o + " as a long integer number");
-				return defaultValue;
-			}
-		}
+
+		return Long.parseLong(o.toString());
 	}
 
-	private boolean convertToBoolean(Object o) {
+	private Boolean convertToBoolean(Object o) {
 		if (o.getClass() == Boolean.class) {
 			return (Boolean) o;
 		}
-		else {
-			return Boolean.parseBoolean(o.toString());
+
+		switch (o.toString().toUpperCase()) {
+			case "TRUE":
+				return true;
+			case "FALSE":
+				return false;
+			default:
+				throw new IllegalArgumentException(String.format(
+					"Unrecognized option for boolean: %s. Expected either true or false(case insensitive)",
+					o));
 		}
 	}
 
-	private float convertToFloat(Object o, float defaultValue) {
+	private Float convertToFloat(Object o) {
 		if (o.getClass() == Float.class) {
 			return (Float) o;
-		}
-		else if (o.getClass() == Double.class) {
+		} else if (o.getClass() == Double.class) {
 			double value = ((Double) o);
 			if (value == 0.0
 					|| (value >= Float.MIN_VALUE && value <= Float.MAX_VALUE)
 					|| (value >= -Float.MAX_VALUE && value <= -Float.MIN_VALUE)) {
 				return (float) value;
 			} else {
-				LOG.warn("Configuration value {} overflows/underflows the float type.", value);
-				return defaultValue;
+				throw new IllegalArgumentException(String.format(
+					"Configuration value %s overflows/underflows the float type.",
+					value));
 			}
 		}
-		else {
-			try {
-				return Float.parseFloat(o.toString());
-			}
-			catch (NumberFormatException e) {
-				LOG.warn("Configuration cannot evaluate value {} as a float value", o);
-				return defaultValue;
-			}
-		}
+
+		return Float.parseFloat(o.toString());
 	}
 
-	private double convertToDouble(Object o, double defaultValue) {
+	private Double convertToDouble(Object o) {
 		if (o.getClass() == Double.class) {
 			return (Double) o;
-		}
-		else if (o.getClass() == Float.class) {
+		} else if (o.getClass() == Float.class) {
 			return ((Float) o).doubleValue();
 		}
-		else {
-			try {
-				return Double.parseDouble(o.toString());
-			}
-			catch (NumberFormatException e) {
-				LOG.warn("Configuration cannot evaluate value {} as a double value", o);
-				return defaultValue;
-			}
-		}
+
+		return Double.parseDouble(o.toString());
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -984,7 +1070,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 						value = bytes;
 						break;
 					default:
-						throw new IOException("Unrecognized type: " + type);
+						throw new IOException(String.format("Unrecognized type: %s. This method is deprecated and" +
+							" might not work for all supported types.", type));
 				}
 
 				this.confData.put(key, value);
@@ -1035,7 +1122,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 					out.writeBoolean((Boolean) val);
 				}
 				else {
-					throw new IllegalArgumentException("Unrecognized type");
+					throw new IllegalArgumentException("Unrecognized type. This method is deprecated and might not work" +
+						" for all supported types.");
 				}
 			}
 		}
@@ -1052,7 +1140,6 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 		return hash;
 	}
 
-	@SuppressWarnings("EqualsBetweenInconvertibleTypes")
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -332,6 +333,21 @@ public final class DelegatingConfiguration extends Configuration {
 		return backingConfig.contains(prefixOption(configOption, prefix));
 	}
 
+	@Override
+	public <T> T get(ConfigOption<T> option) {
+		return backingConfig.get(prefixOption(option, prefix));
+	}
+
+	@Override
+	public <T> Optional<T> getOptional(ConfigOption<T> option) {
+		return backingConfig.getOptional(prefixOption(option, prefix));
+	}
+
+	@Override
+	public <T> WritableConfig set(ConfigOption<T> option, T value) {
+		return backingConfig.set(prefixOption(option, prefix), value);
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	@Override
@@ -379,9 +395,12 @@ public final class DelegatingConfiguration extends Configuration {
 		}
 
 		FallbackKey[] deprecated = deprecatedKeys.toArray(new FallbackKey[0]);
-		return new ConfigOption<>(key,
+		return new ConfigOption<T>(
+			key,
+			option.getClazz(),
 			option.description(),
 			option.defaultValue(),
+			option.isList(),
 			deprecated);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ReadableConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ReadableConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Optional;
+
+/**
+ * Read access to a configuration object. Allows reading values described with meta information
+ * included in {@link ConfigOption}.
+ */
+@PublicEvolving
+public interface ReadableConfig {
+
+	/**
+	 * Reads a value using the metada included in {@link ConfigOption}. Returns the
+	 * {@link ConfigOption#defaultValue()} if value key not present in the configuration.
+	 *
+	 * @param option metadata of the option to read
+	 * @param <T> type of the value to read
+	 * @return read value or {@link ConfigOption#defaultValue()} if not found
+	 * @see #getOptional(ConfigOption)
+	 */
+	<T> T get(ConfigOption<T> option);
+
+	/**
+	 * Reads a value using the metada included in {@link ConfigOption}. In contrast to
+	 * {@link #get(ConfigOption)} returns {@link Optional#empty()} if value not present.
+	 *
+	 * @param option metadata of the option to read
+	 * @param <T> type of the value to read
+	 * @return read value or {@link Optional#empty()} if not found
+	 * @see #get(ConfigOption)
+	 */
+	<T> Optional<T> getOptional(ConfigOption<T> option);
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/StructuredOptionsSplitter.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StructuredOptionsSplitter.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Helper class for splitting a string on a given delimiter with quoting logic.
+ */
+@Internal
+class StructuredOptionsSplitter {
+
+	/**
+	 * Splits the given string on the given delimiter. It supports quoting parts of the string with
+	 * either single (') or double quotes ("). Quotes can be escaped by doubling the quotes.
+	 *
+	 * <p>Examples:
+	 * <ul>
+	 *     <li>'A;B';C => [A;B], [C]</li>
+	 *     <li>"AB'D";B;C => [AB'D], [B], [C]</li>
+	 *     <li>"AB'""D;B";C => [AB'\"D;B], [C]</li>
+	 * </ul>
+	 *
+	 * <p>For more examples check the tests.
+	 * @param string a string to split
+	 * @param delimiter delimiter to split on
+	 * @return a list of splits
+	 */
+	static List<String> splitEscaped(String string, char delimiter) {
+		List<Token> tokens = tokenize(checkNotNull(string), delimiter);
+		return processTokens(tokens);
+	}
+
+	private static List<String> processTokens(List<Token> tokens) {
+		final List<String> splits = new ArrayList<>();
+		for (int i = 0; i < tokens.size(); i++) {
+			Token token = tokens.get(i);
+			switch (token.getTokenType()) {
+				case DOUBLE_QUOTED:
+				case SINGLE_QUOTED:
+					if (i + 1 < tokens.size() && tokens.get(i + 1).getTokenType() != TokenType.DELIMITER) {
+						int illegalPosition = tokens.get(i + 1).getPosition() - 1;
+						throw new IllegalArgumentException(
+							"Could not split string. Illegal quoting at position: " + illegalPosition);
+					}
+					splits.add(token.getString());
+					break;
+				case UNQUOTED:
+					splits.add(token.getString());
+					break;
+				case DELIMITER:
+					if (i + 1 < tokens.size() && tokens.get(i + 1).getTokenType() == TokenType.DELIMITER) {
+						splits.add("");
+					}
+					break;
+			}
+		}
+
+		return splits;
+	}
+
+	private static List<Token> tokenize(String string, char delimiter) {
+		final List<Token> tokens = new ArrayList<>();
+		final StringBuilder builder = new StringBuilder();
+		for (int cursor = 0; cursor < string.length(); ) {
+			final char c = string.charAt(cursor);
+
+			int nextChar = cursor + 1;
+			if (c == '\'') {
+				nextChar = consumeInQuotes(string, '\'', cursor, builder);
+				tokens.add(new Token(TokenType.SINGLE_QUOTED, builder.toString(), cursor));
+			} else if (c == '"') {
+				nextChar = consumeInQuotes(string, '"', cursor, builder);
+				tokens.add(new Token(TokenType.DOUBLE_QUOTED, builder.toString(), cursor));
+			} else if (c == delimiter) {
+				tokens.add(new Token(TokenType.DELIMITER, String.valueOf(c), cursor));
+			} else if (!Character.isWhitespace(c)) {
+				nextChar = consumeUnquoted(string, delimiter, cursor, builder);
+				tokens.add(new Token(TokenType.UNQUOTED, builder.toString().trim(), cursor));
+			}
+			builder.setLength(0);
+			cursor = nextChar;
+		}
+
+		return tokens;
+	}
+
+	private static int consumeInQuotes(String string, char quote, int cursor, StringBuilder builder) {
+		for (int i = cursor + 1; i < string.length(); i++) {
+			char c = string.charAt(i);
+			if (c == quote) {
+				if (i + 1 < string.length() && string.charAt(i + 1) == quote) {
+					builder.append(c);
+					i += 1;
+				} else {
+					return i + 1;
+				}
+			} else {
+				builder.append(c);
+			}
+		}
+
+		throw new IllegalArgumentException("Could not split string. Quoting was not closed properly.");
+	}
+
+	private static int consumeUnquoted(String string, char delimiter, int cursor, StringBuilder builder) {
+		int i;
+		for (i = cursor; i < string.length(); i++) {
+			char c = string.charAt(i);
+			if (c == delimiter) {
+				return i;
+			} else if (c == '\'' || c == '"') {
+				throw new IllegalArgumentException("Could not split string. Illegal quoting at position: " + i);
+			}
+
+			builder.append(c);
+		}
+
+		return i;
+	}
+
+	private enum TokenType {
+		DOUBLE_QUOTED,
+		SINGLE_QUOTED,
+		UNQUOTED,
+		DELIMITER
+	}
+
+	private static class Token {
+		private final TokenType tokenType;
+		private final String string;
+		private final int position;
+
+		private Token(TokenType tokenType, String string, int position) {
+			this.tokenType = tokenType;
+			this.string = string;
+			this.position = position;
+		}
+
+		public TokenType getTokenType() {
+			return tokenType;
+		}
+
+		public String getString() {
+			return string;
+		}
+
+		public int getPosition() {
+			return position;
+		}
+	}
+
+	private StructuredOptionsSplitter() {
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/WritableConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/WritableConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Write access to a configuration object. Allows storing values described with meta information
+ * included in {@link ConfigOption}.
+ */
+@PublicEvolving
+public interface WritableConfig {
+
+	/**
+	 * Stores a given value using the metadata included in the {@link ConfigOption}.
+	 * The value should be readable back through {@link ReadableConfig}.
+	 *
+	 * @param option metadata information
+	 * @param value value to be stored
+	 * @param <T> type of the value to be stored
+	 * @return instance of this configuration for fluent API
+	 */
+	<T> WritableConfig set(ConfigOption<T> option, T value);
+}

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationConversionsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationConversionsTest.java
@@ -1,0 +1,378 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.Matchers.closeTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link Configuration} conversion between types. Extracted from {@link ConfigurationTest}.
+ */
+@RunWith(Parameterized.class)
+public class ConfigurationConversionsTest {
+
+	private static final byte[] EMPTY_BYTES = new byte[0];
+	private static final long TOO_LONG = Integer.MAX_VALUE + 10L;
+	private static final double TOO_LONG_DOUBLE = Double.MAX_VALUE;
+
+	private Configuration pc;
+
+	@Before
+	public void init() {
+		pc = new Configuration();
+
+		pc.setInteger("int", 5);
+		pc.setLong("long", 15);
+		pc.setLong("too_long", TOO_LONG);
+		pc.setFloat("float", 2.1456775f);
+		pc.setDouble("double", Math.PI);
+		pc.setDouble("negative_double", -1.0);
+		pc.setDouble("zero", 0.0);
+		pc.setDouble("too_long_double", TOO_LONG_DOUBLE);
+		pc.setString("string", "42");
+		pc.setString("non_convertible_string", "bcdefg&&");
+		pc.setBoolean("boolean", true);
+	}
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Parameterized.Parameters
+	public static Collection<TestSpec> getSpecs() {
+		return Arrays.asList(
+			// from integer
+			TestSpec.whenAccessed(conf -> conf.getInteger("int", 0)).expect(5),
+			TestSpec.whenAccessed(conf -> conf.getLong("int", 0)).expect(5L),
+			TestSpec.whenAccessed(conf -> conf.getFloat("int", 0)).expect(5f),
+			TestSpec.whenAccessed(conf -> conf.getDouble("int", 0)).expect(5.0),
+			TestSpec.whenAccessed(conf -> conf.getBoolean("int", true))
+				.expectException("Unrecognized option for boolean: 5. Expected either true or false(case insensitive)"),
+			TestSpec.whenAccessed(conf -> conf.getString("int", "0")).expect("5"),
+			TestSpec.whenAccessed(conf -> conf.getBytes("int", EMPTY_BYTES))
+				.expectException("Configuration cannot evaluate value 5 as a byte[] value"),
+			TestSpec.whenAccessed(conf -> conf.getClass(
+				"int",
+				ConfigurationConversionsTest.class,
+				ConfigurationConversionsTest.class.getClassLoader()))
+				.expectException("Configuration cannot evaluate object of class class java.lang.Integer as a class name"),
+
+			// from long
+			TestSpec.whenAccessed(conf -> conf.getInteger("long", 0)).expect(15),
+			TestSpec.whenAccessed(conf -> conf.getLong("long", 0)).expect(15L),
+			TestSpec.whenAccessed(conf -> conf.getFloat("long", 0)).expect(15f),
+			TestSpec.whenAccessed(conf -> conf.getDouble("long", 0)).expect(15.0),
+			TestSpec.whenAccessed(conf -> conf.getBoolean("long", true))
+				.expectException("Unrecognized option for boolean: 15. Expected either true or false(case insensitive)"),
+			TestSpec.whenAccessed(conf -> conf.getString("long", "0")).expect("15"),
+			TestSpec.whenAccessed(conf -> conf.getBytes("long", EMPTY_BYTES))
+				.expectException("Configuration cannot evaluate value 15 as a byte[] value"),
+			TestSpec.whenAccessed(conf -> conf.getClass(
+				"long",
+				ConfigurationConversionsTest.class,
+				ConfigurationConversionsTest.class.getClassLoader()))
+				.expectException("Configuration cannot evaluate object of class class java.lang.Long as a class name"),
+
+			// from too long
+			TestSpec.whenAccessed(conf -> conf.getInteger("too_long", 0))
+				.expectException("Configuration value 2147483657 overflows/underflows the integer type"),
+			TestSpec.whenAccessed(conf -> conf.getLong("too_long", 0)).expect(TOO_LONG),
+			TestSpec.whenAccessed(conf -> conf.getFloat("too_long", 0)).expect((float) TOO_LONG),
+			TestSpec.whenAccessed(conf -> conf.getDouble("too_long", 0)).expect((double) TOO_LONG),
+			TestSpec.whenAccessed(conf -> conf.getBoolean("too_long", true))
+				.expectException(
+					"Unrecognized option for boolean: 2147483657. Expected either true or false(case insensitive)"),
+			TestSpec.whenAccessed(conf -> conf.getString("too_long", "0")).expect(String.valueOf(TOO_LONG)),
+			TestSpec.whenAccessed(conf -> conf.getBytes("too_long", EMPTY_BYTES))
+				.expectException("Configuration cannot evaluate value 2147483657 as a byte[] value"),
+			TestSpec.whenAccessed(conf -> conf.getClass(
+				"too_long",
+				ConfigurationConversionsTest.class,
+				ConfigurationConversionsTest.class.getClassLoader()))
+				.expectException("Configuration cannot evaluate object of class class java.lang.Long as a class name"),
+
+			// from float
+			TestSpec.whenAccessed(conf -> conf.getInteger("float", 0))
+				.expectException("For input string: \"2.1456776\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getLong("float", 0))
+				.expectException("For input string: \"2.1456776\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getFloat("float", 0))
+				.expect(2.1456775f),
+			TestSpec.whenAccessed(conf -> conf.getDouble("float", 0)).expect(closeTo(2.1456775, 0.0000001)),
+			TestSpec.whenAccessed(conf -> conf.getBoolean("float", true))
+				.expectException(
+					"Unrecognized option for boolean: 2.1456776. Expected either true or false(case insensitive)"),
+			TestSpec.whenAccessed(conf -> conf.getString("float", "0")).expect(startsWith("2.145677")),
+			TestSpec.whenAccessed(conf -> conf.getBytes("float", EMPTY_BYTES))
+				.expectException("Configuration cannot evaluate value 2.1456776 as a byte[] value"),
+			TestSpec.whenAccessed(conf -> conf.getClass(
+				"float",
+				ConfigurationConversionsTest.class,
+				ConfigurationConversionsTest.class.getClassLoader()))
+				.expectException("onfiguration cannot evaluate object of class class java.lang.Float as a class name"),
+
+			// from double
+			TestSpec.whenAccessed(conf -> conf.getInteger("double", 0))
+				.expectException("For input string: \"3.141592653589793\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getLong("double", 0))
+				.expectException("For input string: \"3.141592653589793\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getFloat("double", 0)).expect(new IsCloseTo(3.141592f, 0.000001f)),
+			TestSpec.whenAccessed(conf -> conf.getDouble("double", 0)).expect(Math.PI),
+			TestSpec.whenAccessed(conf -> conf.getBoolean("double", true))
+				.expectException(
+					"Unrecognized option for boolean: 3.141592653589793. Expected either true or false(case insensitive)"),
+			TestSpec.whenAccessed(conf -> conf.getString("double", "0")).expect(startsWith("3.1415926535")),
+			TestSpec.whenAccessed(conf -> conf.getBytes("double", EMPTY_BYTES))
+				.expectException("Configuration cannot evaluate value 3.141592653589793 as a byte[] value"),
+			TestSpec.whenAccessed(conf -> conf.getClass(
+				"double",
+				ConfigurationConversionsTest.class,
+				ConfigurationConversionsTest.class.getClassLoader()))
+				.expectException("onfiguration cannot evaluate object of class class java.lang.Double as a class name"),
+
+			// from negative double
+			TestSpec.whenAccessed(conf -> conf.getInteger("negative_double", 0))
+				.expectException("For input string: \"-1.0\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getLong("negative_double", 0))
+				.expectException("For input string: \"-1.0\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getFloat("negative_double", 0))
+				.expect(new IsCloseTo(-1f, 0.000001f)),
+			TestSpec.whenAccessed(conf -> conf.getDouble("negative_double", 0)).expect(-1D),
+			TestSpec.whenAccessed(conf -> conf.getBoolean("negative_double", true))
+				.expectException("Unrecognized option for boolean: -1.0. Expected either true or false(case insensitive)"),
+			TestSpec.whenAccessed(conf -> conf.getString("negative_double", "0")).expect(startsWith("-1")),
+			TestSpec.whenAccessed(conf -> conf.getBytes("negative_double", EMPTY_BYTES))
+				.expectException("Configuration cannot evaluate value -1.0 as a byte[] value"),
+			TestSpec.whenAccessed(conf -> conf.getClass(
+				"negative_double",
+				ConfigurationConversionsTest.class,
+				ConfigurationConversionsTest.class.getClassLoader()))
+				.expectException("Configuration cannot evaluate object of class class java.lang.Double as a class name"),
+
+			// from zero
+			TestSpec.whenAccessed(conf -> conf.getInteger("zero", 0))
+				.expectException("For input string: \"0.0\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getLong("zero", 0))
+				.expectException("For input string: \"0.0\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getFloat("zero", 0)).expect(new IsCloseTo(0f, 0.000001f)),
+			TestSpec.whenAccessed(conf -> conf.getDouble("zero", 0)).expect(0D),
+			TestSpec.whenAccessed(conf -> conf.getBoolean("zero", true))
+				.expectException("Unrecognized option for boolean: 0.0. Expected either true or false(case insensitive)"),
+			TestSpec.whenAccessed(conf -> conf.getString("zero", "0")).expect(startsWith("0")),
+			TestSpec.whenAccessed(conf -> conf.getBytes("zero", EMPTY_BYTES))
+				.expectException("Configuration cannot evaluate value 0.0 as a byte[] value"),
+			TestSpec.whenAccessed(conf -> conf.getClass(
+				"zero",
+				ConfigurationConversionsTest.class,
+				ConfigurationConversionsTest.class.getClassLoader()))
+				.expectException("Configuration cannot evaluate object of class class java.lang.Double as a class name"),
+
+			// from too long double
+			TestSpec.whenAccessed(conf -> conf.getInteger("too_long_double", 0))
+				.expectException("For input string: \"1.7976931348623157E308\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getLong("too_long_double", 0))
+				.expectException("For input string: \"1.7976931348623157E308\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getFloat("too_long_double", 0))
+				.expectException("Configuration value 1.7976931348623157E308 overflows/underflows the float type."),
+			TestSpec.whenAccessed(conf -> conf.getDouble("too_long_double", 0)).expect(TOO_LONG_DOUBLE),
+			TestSpec.whenAccessed(conf -> conf.getBoolean("too_long_double", true))
+				.expectException("Unrecognized option for boolean: 1.7976931348623157E308. Expected either true or false(case insensitive)"),
+			TestSpec.whenAccessed(conf -> conf.getString("too_long_double", "0"))
+				.expect(String.valueOf(TOO_LONG_DOUBLE)),
+			TestSpec.whenAccessed(conf -> conf.getBytes("too_long_double", EMPTY_BYTES))
+				.expectException("Configuration cannot evaluate value 1.7976931348623157E308 as a byte[] value"),
+			TestSpec.whenAccessed(conf -> conf.getClass(
+				"too_long_double",
+				ConfigurationConversionsTest.class,
+				ConfigurationConversionsTest.class.getClassLoader()))
+				.expectException("Configuration cannot evaluate object of class class java.lang.Double as a class name"),
+
+			// from string
+			TestSpec.whenAccessed(conf -> conf.getInteger("string", 0)).expect(42),
+			TestSpec.whenAccessed(conf -> conf.getLong("string", 0)).expect(42L),
+			TestSpec.whenAccessed(conf -> conf.getFloat("string", 0)).expect(42f),
+			TestSpec.whenAccessed(conf -> conf.getDouble("string", 0)).expect(42.0),
+			TestSpec.whenAccessed(conf -> conf.getBoolean("string", true))
+				.expectException("Unrecognized option for boolean: 42. Expected either true or false(case insensitive)"),
+			TestSpec.whenAccessed(conf -> conf.getString("string", "0")).expect("42"),
+			TestSpec.whenAccessed(conf -> conf.getBytes("string", EMPTY_BYTES))
+				.expectException("Configuration cannot evaluate value 42 as a byte[] value"),
+			TestSpec.whenAccessed(conf -> conf.getClass(
+				"string",
+				ConfigurationConversionsTest.class,
+				ConfigurationConversionsTest.class.getClassLoader()))
+				.expectException("42", ClassNotFoundException.class),
+
+			// from non convertible string
+			TestSpec.whenAccessed(conf -> conf.getInteger("non_convertible_string", 0))
+				.expectException("For input string: \"bcdefg&&\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getLong("non_convertible_string", 0))
+				.expectException("For input string: \"bcdefg&&\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getFloat("non_convertible_string", 0))
+				.expectException("For input string: \"bcdefg&&\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getDouble("non_convertible_string", 0))
+				.expectException("For input string: \"bcdefg&&\"", NumberFormatException.class),
+			TestSpec.whenAccessed(conf -> conf.getBoolean("non_convertible_string", true))
+				.expectException("Unrecognized option for boolean: bcdefg&&. Expected either true or false(case insensitive)"),
+			TestSpec.whenAccessed(conf -> conf.getString("non_convertible_string", "0")).expect("bcdefg&&"),
+			TestSpec.whenAccessed(conf -> conf.getBytes("non_convertible_string", EMPTY_BYTES))
+				.expectException("Configuration cannot evaluate value bcdefg&& as a byte[] value"),
+			TestSpec.whenAccessed(conf -> conf.getClass(
+				"non_convertible_string",
+				ConfigurationConversionsTest.class,
+				ConfigurationConversionsTest.class.getClassLoader()))
+				.expectException("bcdefg&&", ClassNotFoundException.class),
+
+			// from boolean
+			TestSpec.whenAccessed(conf -> conf.getInteger("boolean", 0))
+				.expectException("For input string: \"true\""),
+			TestSpec.whenAccessed(conf -> conf.getLong("boolean", 0))
+				.expectException("For input string: \"true\""),
+			TestSpec.whenAccessed(conf -> conf.getFloat("boolean", 0))
+				.expectException("For input string: \"true\""),
+			TestSpec.whenAccessed(conf -> conf.getDouble("boolean", 0))
+				.expectException("For input string: \"true\""),
+			TestSpec.whenAccessed(conf -> conf.getBoolean("boolean", false)).expect(true),
+			TestSpec.whenAccessed(conf -> conf.getString("boolean", "0")).expect("true"),
+			TestSpec.whenAccessed(conf -> conf.getBytes("boolean", EMPTY_BYTES))
+				.expectException("Configuration cannot evaluate value true as a byte[] value"),
+			TestSpec.whenAccessed(conf -> conf.getClass(
+				"boolean",
+				ConfigurationConversionsTest.class,
+				ConfigurationConversionsTest.class.getClassLoader()))
+				.expectException("Configuration cannot evaluate object of class class java.lang.Boolean as a class name")
+		);
+	}
+
+	@Parameterized.Parameter
+	public TestSpec<?> testSpec;
+
+	@Test
+	public void testConversions() throws Exception {
+		testSpec.getExpectedException().ifPresent(exception -> {
+				thrown.expect(testSpec.getExceptionClass());
+				thrown.expectMessage(exception);
+			}
+		);
+
+		// workaround for type erasure
+		testSpec.assertConfiguration(pc);
+	}
+
+	private static class IsCloseTo extends TypeSafeMatcher<Float> {
+		private final float delta;
+		private final float value;
+
+		public IsCloseTo(float value, float error) {
+			this.delta = error;
+			this.value = value;
+		}
+
+		public boolean matchesSafely(Float item) {
+			return this.actualDelta(item) <= 0.0D;
+		}
+
+		public void describeMismatchSafely(Float item, Description mismatchDescription) {
+			mismatchDescription.appendValue(item).appendText(" differed by ").appendValue(this.actualDelta(item));
+		}
+
+		public void describeTo(Description description) {
+			description.appendText("a numeric value within ")
+				.appendValue(this.delta)
+				.appendText(" of ")
+				.appendValue(this.value);
+		}
+
+		private double actualDelta(Float item) {
+			return Math.abs(item - this.value) - this.delta;
+		}
+	}
+
+	private static class TestSpec<T> {
+		private final ConfigurationAccessor<T> configurationAccessor;
+		private Matcher<T> matcher;
+		@Nullable private String expectedException = null;
+		@Nullable private Class<? extends Exception> exceptionClass;
+
+		@FunctionalInterface
+		private interface ConfigurationAccessor<T> {
+			T access(Configuration configuration) throws Exception;
+		}
+
+		private TestSpec(ConfigurationAccessor<T> configurationAccessor) {
+			this.configurationAccessor = configurationAccessor;
+		}
+
+		public static <T> TestSpec<T> whenAccessed(ConfigurationAccessor<T> configurationAccessor) {
+			return new TestSpec<T>(configurationAccessor);
+		}
+
+		public TestSpec<T> expect(Matcher<T> expected) {
+			this.matcher = expected;
+			return this;
+		}
+
+		public TestSpec<T> expect(T expected) {
+			this.matcher = equalTo(expected);
+			return this;
+		}
+
+		public TestSpec<T> expectException(String message) {
+			this.expectedException = message;
+			this.exceptionClass = IllegalArgumentException.class;
+			return this;
+		}
+
+		public TestSpec<T> expectException(String message, Class<? extends Exception> exceptionClass) {
+			this.expectedException = message;
+			this.exceptionClass = exceptionClass;
+			return this;
+		}
+
+		public Optional<String> getExpectedException() {
+			return Optional.ofNullable(expectedException);
+		}
+
+		@Nullable
+		public Class<? extends Exception> getExceptionClass() {
+			return exceptionClass;
+		}
+
+		void assertConfiguration(Configuration conf) throws Exception {
+			assertThat(configurationAccessor.access(conf), matcher);
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationParsingInvalidFormatsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationParsingInvalidFormatsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.Duration;
+import java.util.Collections;
+
+/**
+ * Tests for reading configuration parameters with invalid formats.
+ */
+@RunWith(Parameterized.class)
+public class ConfigurationParsingInvalidFormatsTest extends TestLogger {
+	@Parameterized.Parameters(name = "option: {0}, invalidString: {1}")
+	public static Object[][] getSpecs() {
+		return new Object[][]{
+			new Object[]{ConfigOptions.key("int").intType().defaultValue(1), "ABC"},
+			new Object[]{ConfigOptions.key("long").longType().defaultValue(1L), "ABC"},
+			new Object[]{ConfigOptions.key("float").floatType().defaultValue(1F), "ABC"},
+			new Object[]{ConfigOptions.key("double").doubleType().defaultValue(1D), "ABC"},
+			new Object[]{ConfigOptions.key("boolean").booleanType().defaultValue(true), "ABC"},
+			new Object[]{ConfigOptions.key("memory").memoryType().defaultValue(MemorySize.parse("1kB")), "ABC"},
+			new Object[]{ConfigOptions.key("duration").durationType().defaultValue(Duration.ofSeconds(1)), "ABC"},
+			new Object[]{ConfigOptions.key("enum").enumType(TestEnum.class).defaultValue(TestEnum.ENUM1), "ABC"},
+			new Object[]{ConfigOptions.key("map").mapType().defaultValue(Collections.emptyMap()), "ABC"},
+			new Object[]{ConfigOptions.key("list<int>").intType().asList().defaultValues(1, 2), "A;B;C"},
+			new Object[]{ConfigOptions.key("list<string>").stringType().asList().defaultValues("A"), "'A;B;C"}
+		};
+	}
+
+	@Parameterized.Parameter
+	public ConfigOption<?> option;
+
+	@Parameterized.Parameter(value = 1)
+	public String invalidString;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testInvalidStringParsingWithGetOptional() {
+		Configuration configuration = new Configuration();
+		configuration.setString(option.key(), invalidString);
+
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage(String.format("Could not parse value '%s' for key '%s'", invalidString, option.key()));
+		configuration.getOptional(option);
+	}
+
+	@Test
+	public void testInvalidStringParsingWithGet() {
+		Configuration configuration = new Configuration();
+		configuration.setString(option.key(), invalidString);
+
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage(String.format("Could not parse value '%s' for key '%s'", invalidString, option.key()));
+		configuration.get(option);
+	}
+
+	private enum TestEnum {
+		ENUM1,
+		ENUM2
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -38,10 +38,6 @@ import static org.junit.Assert.fail;
  */
 public class ConfigurationTest extends TestLogger {
 
-	private static final byte[] EMPTY_BYTES = new byte[0];
-	private static final long TOO_LONG = Integer.MAX_VALUE + 10L;
-	private static final double TOO_LONG_DOUBLE = Double.MAX_VALUE;
-
 	/**
 	 * This test checks the serialization/deserialization of configuration objects.
 	 */
@@ -73,128 +69,6 @@ public class ConfigurationTest extends TestLogger {
 			assertEquals(orig.hashCode(), copy.hashCode());
 
 		} catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
-
-	@Test
-	public void testConversions() {
-		try {
-			Configuration pc = new Configuration();
-
-			pc.setInteger("int", 5);
-			pc.setLong("long", 15);
-			pc.setLong("too_long", TOO_LONG);
-			pc.setFloat("float", 2.1456775f);
-			pc.setDouble("double", Math.PI);
-			pc.setDouble("negative_double", -1.0);
-			pc.setDouble("zero", 0.0);
-			pc.setDouble("too_long_double", TOO_LONG_DOUBLE);
-			pc.setString("string", "42");
-			pc.setString("non_convertible_string", "bcdefg&&");
-			pc.setBoolean("boolean", true);
-
-			// as integer
-			assertEquals(5, pc.getInteger("int", 0));
-			assertEquals(5L, pc.getLong("int", 0));
-			assertEquals(5f, pc.getFloat("int", 0), 0.0);
-			assertEquals(5.0, pc.getDouble("int", 0), 0.0);
-			assertEquals(false, pc.getBoolean("int", true));
-			assertEquals("5", pc.getString("int", "0"));
-			assertArrayEquals(EMPTY_BYTES, pc.getBytes("int", EMPTY_BYTES));
-
-			// as long
-			assertEquals(15, pc.getInteger("long", 0));
-			assertEquals(15L, pc.getLong("long", 0));
-			assertEquals(15f, pc.getFloat("long", 0), 0.0);
-			assertEquals(15.0, pc.getDouble("long", 0), 0.0);
-			assertEquals(false, pc.getBoolean("long", true));
-			assertEquals("15", pc.getString("long", "0"));
-			assertArrayEquals(EMPTY_BYTES, pc.getBytes("long", EMPTY_BYTES));
-
-			// as too long
-			assertEquals(0, pc.getInteger("too_long", 0));
-			assertEquals(TOO_LONG, pc.getLong("too_long", 0));
-			assertEquals((float) TOO_LONG, pc.getFloat("too_long", 0), 10.0);
-			assertEquals((double) TOO_LONG, pc.getDouble("too_long", 0), 10.0);
-			assertEquals(false, pc.getBoolean("too_long", true));
-			assertEquals(String.valueOf(TOO_LONG), pc.getString("too_long", "0"));
-			assertArrayEquals(EMPTY_BYTES, pc.getBytes("too_long", EMPTY_BYTES));
-
-			// as float
-			assertEquals(0, pc.getInteger("float", 0));
-			assertEquals(0L, pc.getLong("float", 0));
-			assertEquals(2.1456775f, pc.getFloat("float", 0), 0.0);
-			assertEquals(2.1456775, pc.getDouble("float", 0), 0.0000001);
-			assertEquals(false, pc.getBoolean("float", true));
-			assertTrue(pc.getString("float", "0").startsWith("2.145677"));
-			assertArrayEquals(EMPTY_BYTES, pc.getBytes("float", EMPTY_BYTES));
-
-			// as double
-			assertEquals(0, pc.getInteger("double", 0));
-			assertEquals(0L, pc.getLong("double", 0));
-			assertEquals(3.141592f, pc.getFloat("double", 0), 0.000001);
-			assertEquals(Math.PI, pc.getDouble("double", 0), 0.0);
-			assertEquals(false, pc.getBoolean("double", true));
-			assertTrue(pc.getString("double", "0").startsWith("3.1415926535"));
-			assertArrayEquals(EMPTY_BYTES, pc.getBytes("double", EMPTY_BYTES));
-
-			// as negative double
-			assertEquals(0, pc.getInteger("negative_double", 0));
-			assertEquals(0L, pc.getLong("negative_double", 0));
-			assertEquals(-1f, pc.getFloat("negative_double", 0), 0.000001);
-			assertEquals(-1, pc.getDouble("negative_double", 0), 0.0);
-			assertEquals(false, pc.getBoolean("negative_double", true));
-			assertTrue(pc.getString("negative_double", "0").startsWith("-1"));
-			assertArrayEquals(EMPTY_BYTES, pc.getBytes("negative_double", EMPTY_BYTES));
-
-			// as zero
-			assertEquals(-1, pc.getInteger("zero", -1));
-			assertEquals(-1L, pc.getLong("zero", -1));
-			assertEquals(0f, pc.getFloat("zero", -1), 0.000001);
-			assertEquals(0.0, pc.getDouble("zero", -1), 0.0);
-			assertEquals(false, pc.getBoolean("zero", true));
-			assertTrue(pc.getString("zero", "-1").startsWith("0"));
-			assertArrayEquals(EMPTY_BYTES, pc.getBytes("zero", EMPTY_BYTES));
-
-			// as too long double
-			assertEquals(0, pc.getInteger("too_long_double", 0));
-			assertEquals(0L, pc.getLong("too_long_double", 0));
-			assertEquals(0f, pc.getFloat("too_long_double", 0f), 0.000001);
-			assertEquals(TOO_LONG_DOUBLE, pc.getDouble("too_long_double", 0), 0.0);
-			assertEquals(false, pc.getBoolean("too_long_double", true));
-			assertEquals(String.valueOf(TOO_LONG_DOUBLE), pc.getString("too_long_double", "0"));
-			assertArrayEquals(EMPTY_BYTES, pc.getBytes("too_long_double", EMPTY_BYTES));
-
-			// as string
-			assertEquals(42, pc.getInteger("string", 0));
-			assertEquals(42L, pc.getLong("string", 0));
-			assertEquals(42f, pc.getFloat("string", 0f), 0.000001);
-			assertEquals(42.0, pc.getDouble("string", 0), 0.0);
-			assertEquals(false, pc.getBoolean("string", true));
-			assertEquals("42", pc.getString("string", "0"));
-			assertArrayEquals(EMPTY_BYTES, pc.getBytes("string", EMPTY_BYTES));
-
-			// as non convertible string
-			assertEquals(0, pc.getInteger("non_convertible_string", 0));
-			assertEquals(0L, pc.getLong("non_convertible_string", 0));
-			assertEquals(0f, pc.getFloat("non_convertible_string", 0f), 0.000001);
-			assertEquals(0.0, pc.getDouble("non_convertible_string", 0), 0.0);
-			assertEquals(false, pc.getBoolean("non_convertible_string", true));
-			assertEquals("bcdefg&&", pc.getString("non_convertible_string", "0"));
-			assertArrayEquals(EMPTY_BYTES, pc.getBytes("non_convertible_string", EMPTY_BYTES));
-
-			// as boolean
-			assertEquals(0, pc.getInteger("boolean", 0));
-			assertEquals(0L, pc.getLong("boolean", 0));
-			assertEquals(0f, pc.getFloat("boolean", 0f), 0.000001);
-			assertEquals(0.0, pc.getDouble("boolean", 0), 0.0);
-			assertEquals(true, pc.getBoolean("boolean", false));
-			assertEquals("true", pc.getString("boolean", "0"));
-			assertArrayEquals(EMPTY_BYTES, pc.getBytes("boolean", EMPTY_BYTES));
-		}
-		catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}

--- a/flink-core/src/test/java/org/apache/flink/configuration/ReadableWritableConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ReadableWritableConfigurationTest.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests read access ({@link ReadableConfig}) to {@link Configuration}.
+ * There are 4 different test scenarios:
+ *
+ * <ol>
+ *  <li>Tests reading an object that is kept as an object (when set directly through
+ * {@link Configuration#set(ConfigOption, Object)}.</li>
+ * <li>Tests reading an object that was read from a config file, thus is stored as a string.</li>
+ * <li>Tests using the {@link ConfigOption#defaultValue()} if no key is present in the {@link Configuration}.</li>
+ * <li>Tests that the {@link ConfigOption#defaultValue()} is not used when calling
+ * {@link ReadableConfig#getOptional(ConfigOption)}.</li>
+ * </ol>
+ */
+@RunWith(Parameterized.class)
+public class ReadableWritableConfigurationTest {
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<TestSpec<?>> getSpecs() {
+		return Arrays.asList(
+
+			new TestSpec<>(
+				ConfigOptions.key("int")
+					.intType()
+					.defaultValue(-1))
+				.valueEquals(12345, "12345")
+				.checkDefaultOverride(5),
+
+			new TestSpec<>(
+				ConfigOptions.key("long")
+					.longType()
+					.defaultValue(-1L))
+				.valueEquals(12345L, "12345")
+				.checkDefaultOverride(5L),
+
+			new TestSpec<>(
+				ConfigOptions.key("float")
+					.floatType()
+					.defaultValue(0.01F))
+				.valueEquals(0.003F, "0.003")
+				.checkDefaultOverride(1.23F),
+
+			new TestSpec<>(
+				ConfigOptions.key("double")
+					.doubleType()
+					.defaultValue(0.01D))
+				.valueEquals(0.003D, "0.003")
+				.checkDefaultOverride(1.23D),
+
+			new TestSpec<>(
+				ConfigOptions.key("boolean")
+					.booleanType()
+					.defaultValue(false))
+				.valueEquals(true, "true")
+				.checkDefaultOverride(true),
+
+			new TestSpec<>(
+				ConfigOptions.key("list<int>")
+					.intType()
+					.asList()
+					.defaultValues(-1, 2, 3))
+				.valueEquals(Arrays.asList(1, 2, 3, 4, 5), "1;2;3;4;5")
+				.checkDefaultOverride(Arrays.asList(1, 2)),
+
+			new TestSpec<>(
+				ConfigOptions.key("list<string>")
+					.stringType()
+					.asList()
+					.defaultValues("A", "B", "C"))
+				.valueEquals(Arrays.asList("A;B", "C"), "'A;B';C")
+				.checkDefaultOverride(Collections.singletonList("C")),
+
+			new TestSpec<>(
+				ConfigOptions.key("interval")
+					.durationType()
+					.defaultValue(Duration.ofHours(3)))
+				.valueEquals(Duration.ofMinutes(3), "3 min")
+				.checkDefaultOverride(Duration.ofSeconds(1)),
+
+			new TestSpec<>(
+				ConfigOptions.key("memory")
+					.memoryType()
+					.defaultValue(new MemorySize(1024)))
+				.valueEquals(new MemorySize(1024 * 1024 * 1024), "1g")
+				.checkDefaultOverride(new MemorySize(2048)),
+
+			new TestSpec<>(
+				ConfigOptions.key("properties")
+					.mapType()
+					.defaultValue(asMap(Collections.singletonList(
+						Tuple2.of("prop1", "value1")
+					))))
+				.valueEquals(asMap(Arrays.asList(
+					Tuple2.of("key1", "value1"),
+					Tuple2.of("key2", "value2")
+				)), "key1:value1,key2:value2")
+				.checkDefaultOverride(Collections.emptyMap()),
+
+			new TestSpec<>(
+				ConfigOptions.key("list<properties>")
+					.mapType()
+					.asList()
+					.defaultValues(asMap(Collections.singletonList(
+						Tuple2.of("prop1", "value1")
+					))))
+				.valueEquals(
+					Arrays.asList(
+						asMap(Arrays.asList(
+							Tuple2.of("key1", "value1"),
+							Tuple2.of("key2", "value2"))
+						),
+						asMap(Arrays.asList(
+							Tuple2.of("key3", "value3")
+						))),
+					"key1:value1,key2:value2;key3:value3")
+				.checkDefaultOverride(Collections.emptyList())
+		);
+	}
+
+	private static Map<String, String> asMap(List<Tuple2<String, String>> entries) {
+		return entries.stream().collect(Collectors.toMap(
+			t -> t.f0,
+			t -> t.f1
+		));
+	}
+
+	@Parameterized.Parameter
+	public TestSpec<?> testSpec;
+
+	@Test
+	public void testGetOptionalFromObject() {
+		Configuration configuration = new Configuration();
+		testSpec.setValue(configuration);
+
+		Optional<?> optional = configuration.getOptional(testSpec.getOption());
+		assertThat(optional.get(), equalTo(testSpec.getValue()));
+	}
+
+	@Test
+	public void testGetOptionalFromString() {
+		ConfigOption<?> option = testSpec.getOption();
+		Configuration configuration = new Configuration();
+		configuration.setString(option.key(), testSpec.getStringValue());
+
+		Optional<?> optional = configuration.getOptional(option);
+		assertThat(optional.get(), equalTo(testSpec.getValue()));
+	}
+
+	@Test
+	public void testGetDefaultValue() {
+		Configuration configuration = new Configuration();
+
+		ConfigOption<?> option = testSpec.getOption();
+		Object value = configuration.get(option);
+		assertThat(value, equalTo(option.defaultValue()));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testGetOptionalDefaultValueOverride() {
+		ReadableConfig configuration = new Configuration();
+
+		ConfigOption<?> option = testSpec.getOption();
+		Object value = ((Optional<Object>) configuration.getOptional(option))
+			.orElse(testSpec.getDefaultValueOverride());
+		assertThat(value, equalTo(testSpec.getDefaultValueOverride()));
+	}
+
+	private static class TestSpec<T> {
+		private final ConfigOption<T> option;
+		private T value;
+		private String stringValue;
+		private T defaultValueOverride;
+
+		private TestSpec(ConfigOption<T> option) {
+			this.option = option;
+		}
+
+		public TestSpec<T> valueEquals(T objectValue, String stringValue) {
+			this.value = objectValue;
+			this.stringValue = stringValue;
+			return this;
+		}
+
+		public TestSpec<T> checkDefaultOverride(T defaultValueOverride) {
+			Preconditions.checkArgument(
+				!Objects.equals(defaultValueOverride, option.defaultValue()),
+				"Default value override should be different from the config option default.");
+			this.defaultValueOverride = defaultValueOverride;
+			return this;
+		}
+
+		public ConfigOption<T> getOption() {
+			return option;
+		}
+
+		public T getValue() {
+			return value;
+		}
+
+		public String getStringValue() {
+			return stringValue;
+		}
+
+		public T getDefaultValueOverride() {
+			return defaultValueOverride;
+		}
+
+		/**
+		 * Workaround to set the value in the configuration. We cannot set in the test itself as the
+		 * type of the TypeSpec is erased, because it used for parameterizing the test suite.
+		 */
+		public void setValue(Configuration configuration) {
+			configuration.set(option, value);
+		}
+
+		@Override
+		public String toString() {
+			return "TestSpec{" +
+				"option=" + option +
+				", value=" + value +
+				", stringValue='" + stringValue + '\'' +
+				", defaultValueOverride=" + defaultValueOverride +
+				'}';
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/configuration/StructuredOptionsSplitterTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/StructuredOptionsSplitterTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link StructuredOptionsSplitter}.
+ */
+@RunWith(Parameterized.class)
+public class StructuredOptionsSplitterTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<TestSpec> getSpecs() {
+		return Arrays.asList(
+
+			// Use single quotes for quoting
+			TestSpec.split("'A;B';C", ';').expect("A;B", "C"),
+			TestSpec.split("'A;B';'C'", ';').expect("A;B", "C"),
+			TestSpec.split("A;B;C", ';').expect("A", "B", "C"),
+			TestSpec.split("'AB''D;B';C", ';').expect("AB'D;B", "C"),
+			TestSpec.split("A'BD;B';C", ';').expectException("Could not split string. Illegal quoting at position: 1"),
+			TestSpec.split("'AB'D;B;C", ';').expectException("Could not split string. Illegal quoting at position: 3"),
+			TestSpec.split("'A", ';').expectException("Could not split string. Quoting was not closed properly."),
+			TestSpec.split("C;'", ';').expectException("Could not split string. Quoting was not closed properly."),
+
+			// Use double quotes for quoting
+			TestSpec.split("\"A;B\";C", ';').expect("A;B", "C"),
+			TestSpec.split("\"A;B\";\"C\"", ';').expect("A;B", "C"),
+			TestSpec.split("A;B;C", ';').expect("A", "B", "C"),
+			TestSpec.split("\"AB\"\"D;B\";C", ';').expect("AB\"D;B", "C"),
+			TestSpec.split("A\"BD;B\";C", ';')
+				.expectException("Could not split string. Illegal quoting at position: 1"),
+			TestSpec.split("\"AB\"D;B;C", ';')
+				.expectException("Could not split string. Illegal quoting at position: 3"),
+			TestSpec.split("\"A", ';').expectException("Could not split string. Quoting was not closed properly."),
+			TestSpec.split("C;\"", ';').expectException("Could not split string. Quoting was not closed properly."),
+
+			// Mix different quoting
+			TestSpec.split("'AB\"D';B;C", ';').expect("AB\"D", "B", "C"),
+			TestSpec.split("'AB\"D;B';C", ';').expect("AB\"D;B", "C"),
+			TestSpec.split("'AB\"''D;B';C", ';').expect("AB\"'D;B", "C"),
+			TestSpec.split("\"AB'D\";B;C", ';').expect("AB'D", "B", "C"),
+			TestSpec.split("\"AB'D;B\";C", ';').expect("AB'D;B", "C"),
+			TestSpec.split("\"AB'\"\"D;B\";C", ';').expect("AB'\"D;B", "C"),
+
+			// Use different delimiter
+			TestSpec.split("'A,B',C", ',').expect("A,B", "C"),
+			TestSpec.split("A,B,C", ',').expect("A", "B", "C"),
+
+			// Whitespaces handling
+			TestSpec.split("   'A;B'    ;   C   ", ';').expect("A;B", "C"),
+			TestSpec.split("   A;B    ;   C   ", ';').expect("A", "B", "C"),
+			TestSpec.split("'A;B'    ;C A", ';').expect("A;B", "C A"),
+			TestSpec.split("' A    ;B'    ;'   C'", ';').expect(" A    ;B", "   C")
+		);
+	}
+
+	@Parameterized.Parameter
+	public TestSpec testSpec;
+
+	@Test
+	public void testParse() {
+		testSpec.getExpectedException().ifPresent(exception -> {
+			thrown.expect(IllegalArgumentException.class);
+			thrown.expectMessage(exception);
+		});
+		List<String> splits = StructuredOptionsSplitter.splitEscaped(testSpec.getString(), testSpec.getDelimiter());
+
+		assertThat(splits, equalTo(testSpec.getExpectedSplits()));
+	}
+
+	private static class TestSpec {
+		private final String string;
+		private final char delimiter;
+		@Nullable private String expectedException = null;
+		private List<String> expectedSplits = null;
+
+		private TestSpec(String string, char delimiter) {
+			this.string = string;
+			this.delimiter = delimiter;
+		}
+
+		public static TestSpec split(String string, char delimiter) {
+			return new TestSpec(string, delimiter);
+		}
+
+		public TestSpec expect(String... splits) {
+			this.expectedSplits = Arrays.asList(splits);
+			return this;
+		}
+
+		public TestSpec expectException(String message) {
+			this.expectedException = message;
+			return this;
+		}
+
+		public String getString() {
+			return string;
+		}
+
+		public char getDelimiter() {
+			return delimiter;
+		}
+
+		public Optional<String> getExpectedException() {
+			return Optional.ofNullable(expectedException);
+		}
+
+		public List<String> getExpectedSplits() {
+			return expectedSplits;
+		}
+
+		@Override
+		public String toString() {
+			return String.format("str = [ %s ], del = '%s', expected = %s",
+				string,
+				delimiter,
+				getExpectedException()
+					.map(e -> String.format("Exception(%s)", e))
+					.orElseGet(() -> expectedSplits.stream().collect(Collectors.joining("], [", "[", "]"))));
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/configuration/UnmodifiableConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/UnmodifiableConfigurationTest.java
@@ -74,7 +74,8 @@ public class UnmodifiableConfigurationTest extends TestLogger {
 			UnmodifiableConfiguration config = new UnmodifiableConfiguration(new Configuration());
 
 			for (Method m : clazz.getMethods()) {
-				if (m.getName().startsWith("set")) {
+				// ignore WritableConfig#set as it is covered in ReadableWritableConfigurationTest
+				if (m.getName().startsWith("set") && !m.getName().equals("set")) {
 
 					Class<?> keyClass = m.getParameterTypes()[0];
 					Class<?> parameterClass = m.getParameterTypes()[1];

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -232,6 +232,19 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		//configure task manager hostname property if hostname override property is supplied
 		Option<String> taskManagerHostnameOption = params.getTaskManagerHostname();
 
+		//configure task manager labels
+		Option<Map<String, String>> taskManagerLabels = params.getTaskManagerLabels();
+		if (taskManagerLabels.isDefined()) {
+			Protos.Labels.Builder labelsBuilder = Protos.Labels.newBuilder();
+			for (Map.Entry<String, String> entry: taskManagerLabels.get().entrySet()) {
+				Protos.Label.Builder labelBuilder = Protos.Label.newBuilder();
+				labelBuilder.setKey(entry.getKey());
+				labelBuilder.setValue(entry.getValue());
+				labelsBuilder.addLabels(labelBuilder);
+			}
+			taskInfo.setLabels(labelsBuilder);
+		}
+
 		if (taskManagerHostnameOption.isDefined()) {
 			// replace the TASK_ID pattern by the actual task id value of the Mesos task
 			final String taskManagerHostname = MesosTaskManagerParameters.TASK_ID_PATTERN

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -264,6 +264,11 @@ public class LaunchableMesosWorker implements LaunchableTask {
 			throw new IllegalArgumentException("insufficient # of ports assigned");
 		}
 
+		// Set unix user which mesos tasks will run as
+		if (params.user().isDefined()) {
+			cmd.setUser(params.user().get());
+		}
+
 		// ship additional files
 		for (ContainerSpecification.Artifact artifact : containerSpec.getArtifacts()) {
 			cmd.addUris(Utils.uri(resolver, artifact));

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -233,10 +233,10 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		Option<String> taskManagerHostnameOption = params.getTaskManagerHostname();
 
 		//configure task manager labels
-		Option<Map<String, String>> taskManagerLabels = params.getTaskManagerLabels();
-		if (taskManagerLabels.isDefined()) {
+		Map<String, String> taskManagerLabels = params.getTaskManagerLabels();
+		if (!taskManagerLabels.isEmpty()) {
 			Protos.Labels.Builder labelsBuilder = Protos.Labels.newBuilder();
-			for (Map.Entry<String, String> entry: taskManagerLabels.get().entrySet()) {
+			for (Map.Entry<String, String> entry: taskManagerLabels.entrySet()) {
 				Protos.Label.Builder labelBuilder = Protos.Label.newBuilder();
 				labelBuilder.setKey(entry.getKey());
 				labelBuilder.setValue(entry.getValue());

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -145,6 +145,13 @@ public class MesosTaskManagerParameters {
 			.withDescription("The labels to be set for TaskManager. Specified as key:value pairs separated by commas. " +
 				"For example, key1:value1,key2:value2.");
 
+	public static final ConfigOption<String> MESOS_RM_TASKS_USER =
+		key("mesos.resourcemanager.tasks.user")
+			.stringType()
+			.defaultValue(System.getProperty("user.name"))
+			.withDescription("The Unix user as which mesos tasks will run, default to the same user as jobmanager.");
+
+
 	/**
 	 * Value for {@code MESOS_RESOURCEMANAGER_TASKS_CONTAINER_TYPE} setting. Tells to use the Mesos containerizer.
 	 */
@@ -184,6 +191,8 @@ public class MesosTaskManagerParameters {
 
 	private final Map<String, String> taskManagerLabels;
 
+	private final Option<String> user;
+
 	public MesosTaskManagerParameters(
 			double cpus,
 			int gpus,
@@ -199,7 +208,8 @@ public class MesosTaskManagerParameters {
 			Option<String> bootstrapCommand,
 			Option<String> taskManagerHostname,
 			Map<String, String> taskManagerLabels,
-			List<String> uris) {
+			List<String> uris,
+			Option<String> user) {
 
 		this.cpus = cpus;
 		this.gpus = gpus;
@@ -216,6 +226,7 @@ public class MesosTaskManagerParameters {
 		this.taskManagerHostname = Preconditions.checkNotNull(taskManagerHostname);
 		this.taskManagerLabels = Preconditions.checkNotNull(taskManagerLabels);
 		this.uris = Preconditions.checkNotNull(uris);
+		this.user = Preconditions.checkNotNull(user);
 	}
 
 	/**
@@ -325,6 +336,10 @@ public class MesosTaskManagerParameters {
 		return uris;
 	}
 
+	public Option<String> user() {
+		return user;
+	}
+
 	@Override
 	public String toString() {
 		return "MesosTaskManagerParameters{" +
@@ -416,6 +431,9 @@ public class MesosTaskManagerParameters {
 		String tmCommand = flinkConfig.getString(MESOS_TM_CMD);
 		Option<String> tmBootstrapCommand = Option.apply(flinkConfig.getString(MESOS_TM_BOOTSTRAP_CMD));
 
+		// obtain the user which is running the task
+		Option<String> user = Option.apply(flinkConfig.getString(MESOS_RM_TASKS_USER));
+
 		return new MesosTaskManagerParameters(
 			cpus,
 			gpus,
@@ -431,7 +449,8 @@ public class MesosTaskManagerParameters {
 			tmBootstrapCommand,
 			taskManagerHostname,
 			taskManagerLabels,
-			uris);
+			uris,
+			user);
 	}
 
 	private static List<ConstraintEvaluator> parseConstraints(String mesosConstraints) {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -182,7 +182,7 @@ public class MesosTaskManagerParameters {
 
 	private final List<String> uris;
 
-	private final Option<Map<String, String>> taskManagerLabels;
+	private final Map<String, String> taskManagerLabels;
 
 	public MesosTaskManagerParameters(
 			double cpus,
@@ -198,7 +198,7 @@ public class MesosTaskManagerParameters {
 			String command,
 			Option<String> bootstrapCommand,
 			Option<String> taskManagerHostname,
-			Option<Map<String, String>> taskManagerLabels,
+			Map<String, String> taskManagerLabels,
 			List<String> uris) {
 
 		this.cpus = cpus;
@@ -314,7 +314,7 @@ public class MesosTaskManagerParameters {
 	/**
 	 * Get the taskManager labels.
 	 */
-	public Option<Map<String, String>> getTaskManagerLabels() {
+	public Map<String, String> getTaskManagerLabels() {
 		return taskManagerLabels;
 	}
 
@@ -410,7 +410,7 @@ public class MesosTaskManagerParameters {
 		Option<String> taskManagerHostname = Option.apply(flinkConfig.getString(MESOS_TM_HOSTNAME));
 
 		//obtain Task Manager labels from the configuration
-		Option<Map<String, String>> taskManagerLabels = Option.apply(flinkConfig.getOptional(MESOS_RM_TASKS_LABELS).orElse(Collections.emptyMap()));
+		Map<String, String> taskManagerLabels = flinkConfig.getOptional(MESOS_RM_TASKS_LABELS).orElse(Collections.emptyMap());
 
 		//obtain command-line from the configuration
 		String tmCommand = flinkConfig.getString(MESOS_TM_CMD);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -34,6 +34,7 @@ import org.apache.mesos.Protos;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import scala.Option;
@@ -137,6 +138,13 @@ public class MesosTaskManagerParameters {
 				"Example: az:eu-west-1a,series:t2")
 			.build());
 
+	public static final ConfigOption<Map<String, String>> MESOS_RM_TASKS_LABELS =
+		key("mesos.resourcemanager.tasks.labels")
+			.mapType()
+			.noDefaultValue()
+			.withDescription("The labels to be set for TaskManager. Specified as key:value pairs separated by commas. " +
+				"For example, key1:value1,key2:value2.");
+
 	/**
 	 * Value for {@code MESOS_RESOURCEMANAGER_TASKS_CONTAINER_TYPE} setting. Tells to use the Mesos containerizer.
 	 */
@@ -174,6 +182,8 @@ public class MesosTaskManagerParameters {
 
 	private final List<String> uris;
 
+	private final Option<Map<String, String>> taskManagerLabels;
+
 	public MesosTaskManagerParameters(
 			double cpus,
 			int gpus,
@@ -188,6 +198,7 @@ public class MesosTaskManagerParameters {
 			String command,
 			Option<String> bootstrapCommand,
 			Option<String> taskManagerHostname,
+			Option<Map<String, String>> taskManagerLabels,
 			List<String> uris) {
 
 		this.cpus = cpus;
@@ -203,6 +214,7 @@ public class MesosTaskManagerParameters {
 		this.command = Preconditions.checkNotNull(command);
 		this.bootstrapCommand = Preconditions.checkNotNull(bootstrapCommand);
 		this.taskManagerHostname = Preconditions.checkNotNull(taskManagerHostname);
+		this.taskManagerLabels = Preconditions.checkNotNull(taskManagerLabels);
 		this.uris = Preconditions.checkNotNull(uris);
 	}
 
@@ -300,6 +312,13 @@ public class MesosTaskManagerParameters {
 	}
 
 	/**
+	 * Get the taskManager labels.
+	 */
+	public Option<Map<String, String>> getTaskManagerLabels() {
+		return taskManagerLabels;
+	}
+
+	/**
 	 * Get custom artifact URIs.
 	 */
 	public List<String> uris() {
@@ -390,6 +409,9 @@ public class MesosTaskManagerParameters {
 		//obtain Task Manager Host Name from the configuration
 		Option<String> taskManagerHostname = Option.apply(flinkConfig.getString(MESOS_TM_HOSTNAME));
 
+		//obtain Task Manager labels from the configuration
+		Option<Map<String, String>> taskManagerLabels = Option.apply(flinkConfig.getOptional(MESOS_RM_TASKS_LABELS).orElse(Collections.emptyMap()));
+
 		//obtain command-line from the configuration
 		String tmCommand = flinkConfig.getString(MESOS_TM_CMD);
 		Option<String> tmBootstrapCommand = Option.apply(flinkConfig.getString(MESOS_TM_BOOTSTRAP_CMD));
@@ -408,6 +430,7 @@ public class MesosTaskManagerParameters {
 			tmCommand,
 			tmBootstrapCommand,
 			taskManagerHostname,
+			taskManagerLabels,
 			uris);
 	}
 

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -280,7 +280,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				1.0, 1, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
 				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(), false,
 				Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
-				Option.<String>empty(), Option.apply(Collections.emptyMap()), Collections.<String>emptyList());
+				Option.<String>empty(), Collections.emptyMap(), Collections.<String>emptyList());
 
 			// resource manager
 			rmResourceID = ResourceID.generate();

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -280,7 +280,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				1.0, 1, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
 				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(), false,
 				Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
-				Option.<String>empty(), Collections.emptyMap(), Collections.<String>emptyList());
+				Option.<String>empty(), Collections.emptyMap(), Collections.<String>emptyList(), Option.empty());
 
 			// resource manager
 			rmResourceID = ResourceID.generate();

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -280,7 +280,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				1.0, 1, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
 				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(), false,
 				Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
-				Option.<String>empty(), Collections.<String>emptyList());
+				Option.<String>empty(), Option.apply(Collections.emptyMap()), Collections.<String>emptyList());
 
 			// resource manager
 			rmResourceID = ResourceID.generate();


### PR DESCRIPTION
## What is the purpose of the change
[FLINK-17401]  Currently labels are not set in the task info object. A lot of companies can have logic specific to labels on TM. For example in criteo, based on labels we set kerberos env variables and mesos debug capabilities. It is critical for us to be able to pass these label values to the task manager.

## Brief change log

Reading the labels as map structure from flink config and pass it to mesos task parameters. TaskInfo object is populated with the labels by LaunchableMesosWorker.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  don't know
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs 

(Note the oss review is here : [FLINK-17401] Add Labels to the mesos task info #11923) https://github.com/apache/flink/pull/11923