### PR TITLE
Flink's ZK in HA mode setup is unable to start up if any of the zk hosts are unreachable

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
@@ -107,8 +107,8 @@ public class SecureTestEnvironment {
 
 			File keytabFile = new File(baseDirForSecureRun, "test-users.keytab");
 			testKeytab = keytabFile.getAbsolutePath();
-			testZkServerPrincipal = "zookeeper/127.0.0.1";
-			testZkClientPrincipal = "zk-client/127.0.0.1";
+			testZkServerPrincipal = "zookeeper/" + hostName;
+			testZkClientPrincipal = "zk-client/" + hostName;
 			testKafkaServerPrincipal = "kafka/" + hostName;
 			hadoopServicePrincipal = "hadoop/" + hostName;
 			testPrincipal = "client/" + hostName;

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ under the License.
 		<scala.version>2.11.12</scala.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<chill.version>0.7.6</chill.version>
-		<zookeeper.version>3.4.10</zookeeper.version>
+		<zookeeper.version>3.4.14</zookeeper.version>
 		<curator.version>2.12.0</curator.version>
 		<jackson.version>2.10.1</jackson.version>
 		<metrics.version>3.1.5</metrics.version>


### PR DESCRIPTION
**Problem:**
We occasionally hit an issue where our Flink cluster will not startup if any of the zookeeper hosts passed in the "high-availability.zookeeper.quorum" config setting are unreachable. This seems to stem from us using an older zookeeper dependency version (3.4.10).

This error seems to stem from us being on an older zookeeper release (3.4.10). On this version the host lookup is done when the `StaticHostProvider` is created on startup of the JM and not refreshed after. Using consul for lookup doesn't help either as we do the consul DNS lookup at startup time and default to one of the n zk hosts chosen then. If that host goes down we'd run into trouble. 

This has been fixed as part of: https://issues.apache.org/jira/browse/ZOOKEEPER-1576 in the 3.4.x branch (https://github.com/apache/zookeeper/commit/be1409cc9a14ac2e28693e0e02a0ba6d9713565e). This review bumps the zk dependency to 3.4.14 to allow us to workaround this. 

Have spun up an upstream jira (https://issues.apache.org/jira/browse/FLINK-17443) which will target the 1.10 branch so we'll want this change in 1.9 anyway. 

**Sample error:**
```
java.net.UnknownHostException: zk01-pa4.hpc.criteo.prod: Name or service not known at 
java.net.Inet6AddressImpl.lookupAllHostAddr(Native Method) at 
java.net.InetAddress$2.lookupAllHostAddr(InetAddress.java:929) at 
java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1324) at 
java.net.InetAddress.getAllByName0(InetAddress.java:1277) at 
java.net.InetAddress.getAllByName(InetAddress.java:1193) at 
java.net.InetAddress.getAllByName(InetAddress.java:1127) at 
org.apache.flink.shaded.zookeeper.org.apache.zookeeper.client.StaticHostProvider.<init>(StaticHostProvider.java:61)  at 
org.apache.flink.shaded.zookeeper.org.apache.zookeeper.ZooKeeper.<init>(ZooKeeper.java:445) at 
org.apache.flink.shaded.curator.org.apache.curator.utils.DefaultZookeeperFactory.newZooKeeper(DefaultZookeeperFactory.java:29) at 
org.apache.flink.shaded.curator.org.apache.curator.framework.imps.CuratorFrameworkImpl$2.newZooKeeper(CuratorFrameworkImpl.java:150) at 
org.apache.flink.shaded.curator.org.apache.curator.HandleHolder$1.getZooKeeper(HandleHolder.java:94) at 
org.apache.flink.shaded.curator.org.apache.curator.HandleHolder.getZooKeeper(HandleHolder.java:55) at 
org.apache.flink.shaded.curator.org.apache.curator.ConnectionState.reset(ConnectionState.java:262) at 
org.apache.flink.shaded.curator.org.apache.curator.ConnectionState.start(ConnectionState.java:109) at 
org.apache.flink.shaded.curator.org.apache.curator.CuratorZookeeperClient.start(CuratorZookeeperClient.java:191) at 
org.apache.flink.shaded.curator.org.apache.curator.framework.imps.CuratorFrameworkImpl.start(CuratorFrameworkImpl.java:259) at 
org.apache.flink.runtime.util.ZooKeeperUtils.startCuratorFramework(ZooKeeperUtils.java:131) at 
org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils.createHighAvailabilityServices(HighAvailabilityServicesUtils.java:123) at 
org.apache.flink.runtime.entrypoint.ClusterEntrypoint.createHaServices(ClusterEntrypoint.java:292) at 
org.apache.flink.runtime.entrypoint.ClusterEntrypoint.initializeServices(ClusterEntrypoint.java:257)
```