### PR TITLE
scala 2.12: Use scala 2.12.20

### DIFF
--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
@@ -201,8 +201,6 @@ object EnumValueSerializerCompatibilityTest {
     val run = new global.Run
 
     run.compile(List(file.getAbsolutePath))
-
-    reporter.printSummary()
   }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -883,7 +883,7 @@ under the License.
 		<profile>
 			<id>scala-2.12</id>
 			<properties>
-				<scala.version>2.12.7</scala.version>
+				<scala.version>2.12.20</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
 			</properties>
 			<activation>


### PR DESCRIPTION
Java serialization issue fixed in scala 2.12.14: https://github.com/scala/scala/pull/9166 Remove `reporter.printSummary` after the scala file compilation, because this api has been removed in scala 2.12.13